### PR TITLE
Dont check for duplicates

### DIFF
--- a/lib/qrz
+++ b/lib/qrz
@@ -375,9 +375,8 @@ if (defined($iota)) {
 if (defined($codes) && $compact ne 1) {
   print " -- codes: $codes $codetext";
 }
-if (@prevcalls) {
-  my @uniqprevcalls = uniq(@prevcalls);
-  print " -- prev " . join(", ", @uniqprevcalls);
+if (@prevcalls) {	if (@prevcalls) {
+  print " -- prev " . join(", ", @prevcalls);
 }
 if (@othercalls) {
   my @uniqothercalls = uniq(@othercalls);


### PR DESCRIPTION
Wrong returned duplicate previous calls have always been great fun, especially for the younger generation.
With this change I hope to get more young people into our great H.A.M.-hobby.