### PR TITLE
fun.tcl: add !no command via No-as-a-Service API

### DIFF
--- a/botcommands.md
+++ b/botcommands.md
@@ -86,6 +86,7 @@
  * `!spacex` -- next spacex launch
  * `!translate` -- translate text
  * `!rand` `!dice` `!flip` `!8ball` `!orb` -- random
+ * `!no` -- random rejection reason from No-as-a-Service
 
 ## Radio-related commands:
 
@@ -1036,6 +1037,10 @@ Example:
 ### `!spacex` -- next spacex launch
 ### `!translate` -- translate text
 ### `!rand` `!dice` `!flip` `!8ball` `!orb` -- random
+
+### `!no` -- random rejection reason
+
+Returns a random, humorous reason to say no, via the No-as-a-Service API.
 
 <!-- !amcon - - some dumb prepper shit -->
 

--- a/lib/no
+++ b/lib/no
@@ -1,0 +1,47 @@
+#!/usr/bin/perl -w
+#
+# Returns a random rejection reason from the No-as-a-Service API.
+# https://naas.isalman.dev/no
+#
+# 2-clause BSD license.
+# Copyright (c) 2025 cjh@github. All rights reserved.
+
+use strict;
+use JSON::PP qw( decode_json );
+
+use File::Basename;
+use Cwd 'realpath';
+use lib dirname(realpath(__FILE__));
+use Colors;
+use Util;
+
+my $username = $ENV{'USER'} || $ENV{'USERNAME'} || getpwuid($<);
+
+our $exitnonzeroonerror = 1;
+$exitnonzeroonerror = 0 if $username eq getEggdropUID();
+
+my $useragent = "qrmbot";
+my $url = 'https://naas.isalman.dev/no';
+
+my $raw = `curl --max-time 10 -s -k -L -A "$useragent" '$url'`;
+
+if (!defined $raw || $raw eq '') {
+  print red("Error: no response from No-as-a-Service API") . "\n";
+  exit $exitnonzeroonerror;
+}
+
+my $data = eval { decode_json($raw) };
+if ($@) {
+  print red("Error: failed to parse response") . "\n";
+  exit $exitnonzeroonerror;
+}
+
+my $reason = $data->{'reason'};
+if (!defined $reason || $reason eq '') {
+  print red("Error: no reason returned") . "\n";
+  exit $exitnonzeroonerror;
+}
+
+print bold("No.") . " " . $reason . "\n";
+
+exit 0;

--- a/scripts/fun.tcl
+++ b/scripts/fun.tcl
@@ -1560,5 +1560,17 @@ proc shame {nick uhost hand chan text} {
 }
 bind pub - !shame shame
 
+bind pub - !no no_pub
+set nobin "/home/eggdrop/bin/no"
+proc no_pub { nick host hand chan text } {
+	global nobin
+	putlog "no pub: $nick $host $hand $chan"
+	set fd [open "|${nobin}" r]
+	fconfigure $fd -encoding utf-8
+	while {[gets $fd line] >= 0} {
+		putchan $chan "$line"
+	}
+	close $fd
+}
 
 putlog "fun.tcl loaded."


### PR DESCRIPTION
Adds a `!no` command that returns a random, humorous rejection reason from the [No-as-a-Service API](https://naas.isalman.dev/no).

This was monkee's idea.

## Changes
- `lib/no` — Perl script that hits `https://naas.isalman.dev/no` and prints `No. <reason>`
- `scripts/fun.tcl` — binds `!no` pub handler
- `botcommands.md` — summary entry and `###` section

## Example output
```
No. My intuition screamed 'no' so loudly, I had to answer accordingly.
No. Think of my 'no' as an act of self-care.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)