### PR TITLE
Add !nhl birds easter egg

### DIFF
--- a/lib/nhl
+++ b/lib/nhl
@@ -68,6 +68,11 @@ if (!defined($input) || $input eq '') {
   exit 0;
 }
 
+if ($input eq 'birds') {
+  print "fuck the birds\n";
+  exit 0;
+}
+
 my $abbrev = $teammap{$input};
 unless (defined $abbrev) {
   (my $stripped = $input) =~ s/^the\s+//i;


### PR DESCRIPTION
## Summary

- Adds a special case in `lib/nhl` so that `!nhl birds` responds with `fuck the birds`
- The check runs after input normalization but before team lookup, following the existing control flow pattern

## Test plan

- [ ] Run `./lib/nhl birds` — should print `fuck the birds`
- [ ] Run `./lib/nhl flyers` — should still return normal Flyers game data
- [ ] Run `./lib/nhl` (no args) — should still print usage message

🤖 Generated with [Claude Code](https://claude.com/claude-code)