### PR TITLE
add !potaleague POTA yearly leaderboard

### DIFF
--- a/botcommands.md
+++ b/botcommands.md
@@ -36,6 +36,9 @@
  * `!league` -- report clublog league standings
  * `!pota` -- search POTA parks and users
  * `!potapark` -- find POTA parks near a given location
+ * `!potaleague` -- POTA yearly activation leaderboard (per channel)
+ * `!potaleagueadd` `!potaleaguereg` -- register a callsign for the POTA league
+ * `!potaleaguedel` `!potaleagueremove` -- remove a callsign from the POTA league
  * `!sota` -- search SOTA summits
  * `!iota` -- search IOTA islands
  * `!1x1` -- search 1x1 special event stations
@@ -831,6 +834,54 @@ Examples:
     <qrm> US-7888: Alcatraz Island National Historic Site -- San Francisco,
         CA, USA -- 5.8 km N
 ```
+
+### `!potaleague` -- POTA yearly activation leaderboard
+
+Usage:
+
+```
+    !potaleague [year]
+```
+
+Shows the POTA activation leaderboard for the current channel for the given
+year (defaults to the current calendar year). Each channel has its own list
+of registered callsigns. Activation and QSO counts are fetched live from the
+POTA API.
+
+Examples:
+
+```
+<molo1134> !potaleague
+<qrm> POTA League 2026: NV3Y 6A,150Q - W0NY 1A,20Q
+
+<molo1134> !potaleague 2025
+<qrm> POTA League 2025: W0NY 12A,500Q - NV3Y 8A,300Q
+```
+
+### `!potaleagueadd` -- register a callsign for the POTA league
+
+Aliases: `!potaleaguereg`
+
+Usage:
+
+```
+    !potaleagueadd <callsign>
+```
+
+Registers a callsign for the POTA league in the current channel.
+Registrations are stored per channel in `$HOME/.qrmbot/db/potaleague`.
+
+### `!potaleaguedel` -- remove a callsign from the POTA league
+
+Aliases: `!potaleagueremove`
+
+Usage:
+
+```
+    !potaleaguedel <callsign>
+```
+
+Removes a callsign from the POTA league in the current channel.
 
 ### `!sota` -- search SOTA summits
 

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -35,7 +35,16 @@ $exitnonzeroonerror = 0 if $username eq getEggdropUID();
 @ARGV = map { decode "utf-8", $_ } @ARGV;
 @ARGV = split(' ', join(' ', @ARGV));
 
-my $leaguefile = $ENV{'HOME'} . "/.qrmbot/db/potaleague";
+my $dbdir      = $ENV{'HOME'} . "/.qrmbot/db";
+my $leaguefile = "$dbdir/potaleague";
+
+if (not -d $dbdir) {
+  print "making db directory..\n";
+  system("mkdir -p $dbdir");
+  if (not -d $dbdir) {
+    print "unable to make db directory $dbdir\n";
+  }
+}
 
 my $year        = strftime("%Y", gmtime(time()));
 my $channel     = undef;

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -1,13 +1,14 @@
 #!/usr/bin/perl
 #
-# POTA yearly league -- !potaleague [year] and !potaleagueadd <callsign>
+# POTA yearly league -- !potaleague [year], !potaleagueadd, !potaleaguedel
 #
-# Registered callsigns persist in $HOME/.qrmbot/potaleague (one per line).
+# Per-channel registrations persist in $HOME/.qrmbot/db/potaleague
+# (one entry per line: "<channel> <callsign>").
 # Activation and QSO counts are fetched live from the POTA API, so any
 # calendar year can be queried as long as POTA retains the history.
 #
 # 2-clause BSD license.
-# Copyright (c) 2026 molo1134@github. All rights reserved.
+# Copyright (c) 2026 nreed97@github. All rights reserved.
 
 # https://api.pota.app/activations/user/<callsign>  -- list of all activations
 # https://api.pota.app/profile/<callsign>            -- user profile / stats
@@ -34,16 +35,25 @@ $exitnonzeroonerror = 0 if $username eq getEggdropUID();
 @ARGV = map { decode "utf-8", $_ } @ARGV;
 @ARGV = split(' ', join(' ', @ARGV));
 
-my $leaguefile = $ENV{'HOME'} . "/.qrmbot/potaleague";
+my $leaguefile = $ENV{'HOME'} . "/.qrmbot/db/potaleague";
 
-my $year      = strftime("%Y", gmtime(time()));
+my $year        = strftime("%Y", gmtime(time()));
+my $channel     = undef;
 my $do_register = 0;
-my $callsign  = undef;
+my $do_remove   = 0;
+my $callsign    = undef;
 
 my $i = 0;
 while ($i <= $#ARGV) {
-  if ($ARGV[$i] =~ /^--(register|add)$/i) {
+  if ($ARGV[$i] =~ /^--channel$/i) {
+    $i++;
+    $channel = lc $ARGV[$i] if defined $ARGV[$i];
+  } elsif ($ARGV[$i] =~ /^--(register|add)$/i) {
     $do_register = 1;
+    $i++;
+    $callsign = uc $ARGV[$i] if defined $ARGV[$i];
+  } elsif ($ARGV[$i] =~ /^--(remove|del|delete)$/i) {
+    $do_remove = 1;
     $i++;
     $callsign = uc $ARGV[$i] if defined $ARGV[$i];
   } elsif ($ARGV[$i] =~ /^\d{4}$/) {
@@ -52,60 +62,110 @@ while ($i <= $#ARGV) {
   $i++;
 }
 
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+sub read_entries {
+  my @entries = ();
+  return @entries unless -f $leaguefile;
+  open(my $fh, '<', $leaguefile) or die "cannot open $leaguefile: $!";
+  while (<$fh>) { chomp; push @entries, $_ if length $_ > 0; }
+  close($fh);
+  return @entries;
+}
+
+sub write_entries {
+  open(my $fh, '>', $leaguefile) or die "cannot write $leaguefile: $!";
+  print $fh "$_\n" for @_;
+  close($fh);
+}
+
 # ── Registration ─────────────────────────────────────────────────────────────
 
 if ($do_register) {
+  if (!defined $channel) {
+    print "error: use !potaleagueadd in a channel\n";
+    exit $exitnonzeroonerror;
+  }
   if (!defined $callsign or $callsign eq "") {
     if ($username eq getEggdropUID()) {
       print "usage: !potaleagueadd <callsign>\n";
     } else {
-      print "usage: $0 --register <callsign>\n";
+      print "usage: $0 --channel <channel> --register <callsign>\n";
     }
     exit $exitnonzeroonerror;
   }
-
   if ($callsign !~ /^[A-Z0-9\/]+$/) {
     print "error: invalid callsign: $callsign\n";
     exit $exitnonzeroonerror;
   }
 
-  my @existing = ();
-  if (-f $leaguefile) {
-    open(my $fh, '<', $leaguefile) or die "cannot open $leaguefile: $!";
-    while (<$fh>) { chomp; push @existing, $_ if length $_ > 0; }
-    close($fh);
-  }
-
-  if (grep { uc $_ eq $callsign } @existing) {
-    print bold($callsign) . " is already in the POTA league\n";
+  my @existing = read_entries();
+  my $key = "$channel $callsign";
+  if (grep { lc $_ eq lc $key } @existing) {
+    print bold($callsign) . " is already in the POTA league for $channel\n";
     exit 0;
   }
 
-  push @existing, $callsign;
-  open(my $fh, '>', $leaguefile) or die "cannot write $leaguefile: $!";
-  print $fh "$_\n" for @existing;
-  close($fh);
+  push @existing, $key;
+  write_entries(@existing);
+  print "registered " . bold($callsign) . " for the POTA league in $channel\n";
+  exit 0;
+}
 
-  print "registered " . bold($callsign) . " for the POTA league\n";
+# ── Removal ───────────────────────────────────────────────────────────────────
+
+if ($do_remove) {
+  if (!defined $channel) {
+    print "error: use !potaleaguedel in a channel\n";
+    exit $exitnonzeroonerror;
+  }
+  if (!defined $callsign or $callsign eq "") {
+    if ($username eq getEggdropUID()) {
+      print "usage: !potaleaguedel <callsign>\n";
+    } else {
+      print "usage: $0 --channel <channel> --remove <callsign>\n";
+    }
+    exit $exitnonzeroonerror;
+  }
+  if ($callsign !~ /^[A-Z0-9\/]+$/) {
+    print "error: invalid callsign: $callsign\n";
+    exit $exitnonzeroonerror;
+  }
+
+  my @existing = read_entries();
+  my $key = "$channel $callsign";
+  my @updated = grep { lc $_ ne lc $key } @existing;
+
+  if (@updated == @existing) {
+    print bold($callsign) . " is not registered in the POTA league for $channel\n";
+    exit 0;
+  }
+
+  write_entries(@updated);
+  print "removed " . bold($callsign) . " from the POTA league in $channel\n";
   exit 0;
 }
 
 # ── Leaderboard ───────────────────────────────────────────────────────────────
 
-my @calls = ();
-if (-f $leaguefile) {
-  open(my $fh, '<', $leaguefile) or die "cannot open $leaguefile: $!";
-  while (<$fh>) { chomp; push @calls, $_ if length $_ > 0; }
-  close($fh);
+my @entries = read_entries();
+my @calls;
+if (defined $channel) {
+  @calls = map  { (split ' ', $_, 2)[1] }
+           grep { lc((split ' ', $_, 2)[0]) eq lc($channel) } @entries;
+} else {
+  my %seen;
+  @calls = grep { !$seen{$_}++ }
+           map  { (split ' ', $_, 2)[1] } @entries;
 }
 
 if (@calls == 0) {
-  print "no callsigns registered for POTA league -- use !potaleagueadd <callsign>\n";
+  my $where = defined $channel ? " in $channel" : "";
+  print "no callsigns registered for POTA league${where} -- use !potaleagueadd <callsign>\n";
   exit 0;
 }
 
 my %stats;
-
 for my $call (@calls) {
   my $url = "https://api.pota.app/activations/user/" . uri_escape($call);
 
@@ -123,13 +183,10 @@ for my $call (@calls) {
 
   my ($act_count, $qso_count) = (0, 0);
   for my $act (@{$acts}) {
-    # date field may be "YYYY-MM-DD" (profile style) or "YYYYMMDD" (park style)
     my $date = $act->{date} // $act->{qso_date} // "";
     my $act_year = ($date =~ /^(\d{4})/) ? $1 : "";
     next unless $act_year eq $year;
-
     $act_count++;
-    # QSO count field varies by endpoint
     $qso_count += $act->{total} // $act->{totalQSOs} // 0;
   }
 
@@ -138,7 +195,8 @@ for my $call (@calls) {
 }
 
 if (keys %stats == 0) {
-  print "no POTA activations found for $year among registered callsigns\n";
+  my $where = defined $channel ? " in $channel" : "";
+  print "no POTA activations found for $year${where}\n";
   exit 0;
 }
 

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -1,0 +1,159 @@
+#!/usr/bin/perl
+#
+# POTA yearly league -- !potaleague [year] and !potaleagueadd <callsign>
+#
+# Registered callsigns persist in $HOME/.qrmbot/potaleague (one per line).
+# Activation and QSO counts are fetched live from the POTA API, so any
+# calendar year can be queried as long as POTA retains the history.
+#
+# 2-clause BSD license.
+# Copyright (c) 2026 molo1134@github. All rights reserved.
+
+# https://api.pota.app/activations/user/<callsign>  -- list of all activations
+# https://api.pota.app/profile/<callsign>            -- user profile / stats
+
+use URI::Escape;
+use JSON qw( decode_json );
+use strict;
+use utf8;
+use feature 'unicode_strings';
+use Encode qw(decode);
+binmode(STDOUT, ":utf8");
+
+use File::Basename;
+use Cwd 'realpath';
+use lib dirname(realpath(__FILE__));
+use Colors;
+use Util;
+use POSIX qw(strftime);
+
+my $username = $ENV{'USER'} || $ENV{'USERNAME'} || getpwuid($<);
+our $exitnonzeroonerror = 1;
+$exitnonzeroonerror = 0 if $username eq getEggdropUID();
+
+@ARGV = map { decode "utf-8", $_ } @ARGV;
+@ARGV = split(' ', join(' ', @ARGV));
+
+my $leaguefile = $ENV{'HOME'} . "/.qrmbot/potaleague";
+
+my $year      = strftime("%Y", gmtime(time()));
+my $do_register = 0;
+my $callsign  = undef;
+
+my $i = 0;
+while ($i <= $#ARGV) {
+  if ($ARGV[$i] =~ /^--(register|add)$/i) {
+    $do_register = 1;
+    $i++;
+    $callsign = uc $ARGV[$i] if defined $ARGV[$i];
+  } elsif ($ARGV[$i] =~ /^\d{4}$/) {
+    $year = $ARGV[$i];
+  }
+  $i++;
+}
+
+# ── Registration ─────────────────────────────────────────────────────────────
+
+if ($do_register) {
+  if (!defined $callsign or $callsign eq "") {
+    if ($username eq getEggdropUID()) {
+      print "usage: !potaleagueadd <callsign>\n";
+    } else {
+      print "usage: $0 --register <callsign>\n";
+    }
+    exit $exitnonzeroonerror;
+  }
+
+  if ($callsign !~ /^[A-Z0-9\/]+$/) {
+    print "error: invalid callsign: $callsign\n";
+    exit $exitnonzeroonerror;
+  }
+
+  my @existing = ();
+  if (-f $leaguefile) {
+    open(my $fh, '<', $leaguefile) or die "cannot open $leaguefile: $!";
+    while (<$fh>) { chomp; push @existing, $_ if length $_ > 0; }
+    close($fh);
+  }
+
+  if (grep { uc $_ eq $callsign } @existing) {
+    print bold($callsign) . " is already in the POTA league\n";
+    exit 0;
+  }
+
+  push @existing, $callsign;
+  open(my $fh, '>', $leaguefile) or die "cannot write $leaguefile: $!";
+  print $fh "$_\n" for @existing;
+  close($fh);
+
+  print "registered " . bold($callsign) . " for the POTA league\n";
+  exit 0;
+}
+
+# ── Leaderboard ───────────────────────────────────────────────────────────────
+
+my @calls = ();
+if (-f $leaguefile) {
+  open(my $fh, '<', $leaguefile) or die "cannot open $leaguefile: $!";
+  while (<$fh>) { chomp; push @calls, $_ if length $_ > 0; }
+  close($fh);
+}
+
+if (@calls == 0) {
+  print "no callsigns registered for POTA league -- use !potaleagueadd <callsign>\n";
+  exit 0;
+}
+
+my %stats;
+
+for my $call (@calls) {
+  my $url = "https://api.pota.app/activations/user/" . uri_escape($call);
+
+  local $/;
+  open(JSON, '-|', "curl -k -L --max-time 15 --retry 1 -s '$url'");
+  my $json = <JSON>;
+  close(JSON);
+
+  next unless defined $json and $json ne "";
+
+  my $acts;
+  eval { $acts = decode_json($json); };
+  next if $@;
+  next unless ref $acts eq 'ARRAY';
+
+  my ($act_count, $qso_count) = (0, 0);
+  for my $act (@{$acts}) {
+    # date field may be "YYYY-MM-DD" (profile style) or "YYYYMMDD" (park style)
+    my $date = $act->{date} // $act->{qso_date} // "";
+    my $act_year = ($date =~ /^(\d{4})/) ? $1 : "";
+    next unless $act_year eq $year;
+
+    $act_count++;
+    # QSO count field varies by endpoint
+    $qso_count += $act->{total} // $act->{totalQSOs} // 0;
+  }
+
+  $stats{$call} = { activations => $act_count, qsos => $qso_count }
+    if $act_count > 0;
+}
+
+if (keys %stats == 0) {
+  print "no POTA activations found for $year among registered callsigns\n";
+  exit 0;
+}
+
+my @sorted = sort {
+  $stats{$b}{activations} <=> $stats{$a}{activations}
+    || $stats{$b}{qsos} <=> $stats{$a}{qsos}
+} keys %stats;
+
+print "POTA League $year: ";
+my $sep = "";
+for my $call (@sorted) {
+  print $sep;
+  print bold($call) . " "
+      . $stats{$call}{activations} . "A,"
+      . commify($stats{$call}{qsos}) . "Q";
+  $sep = " - ";
+}
+print "\n";

--- a/scripts/qrzgrid.tcl
+++ b/scripts/qrzgrid.tcl
@@ -184,6 +184,10 @@ bind msg - !potaleagueadd potaleagueadd_msg
 bind pub - !potaleagueadd potaleagueadd_pub
 bind msg - !potaleaguereg potaleagueadd_msg
 bind pub - !potaleaguereg potaleagueadd_pub
+bind msg - !potaleaguedel potaleaguedel_msg
+bind pub - !potaleaguedel potaleaguedel_pub
+bind msg - !potaleagueremove potaleaguedel_msg
+bind pub - !potaleagueremove potaleaguedel_pub
 
 bind msg - !potaspots potaspots_msg
 bind pub - !potaspots potaspots_pub
@@ -2223,11 +2227,10 @@ proc fest_msg { nick uhand handle input } {
 }
 
 proc potaleague_pub { nick host hand chan text } {
-	if ![string equal "#redditnet" $chan] then { return }
 	global potaleaguebin
 	set params [sanitize_string [string trim "${text}"]]
 	putlog "potaleague pub: $nick $host $hand $chan $params"
-	set fd [open "|${potaleaguebin} ${params}" r]
+	set fd [open "|${potaleaguebin} --channel ${chan} ${params}" r]
 	fconfigure $fd -encoding utf-8
 	while {[gets $fd line] >= 0} {
 		putchan $chan "$line"
@@ -2247,15 +2250,14 @@ proc potaleague_msg {nick uhand handle input} {
 }
 
 proc potaleagueadd_pub { nick host hand chan text } {
-	if ![string equal "#redditnet" $chan] then { return }
 	global potaleaguebin
 	set call [sanitize_string [string trim "${text}"]]
 	putlog "potaleagueadd pub: $nick $host $hand $chan $call"
-	if [string equal "" $call] then {
+	if {[string equal "" $call]} then {
 		putchan $chan "usage: !potaleagueadd <callsign>"
 		return
 	}
-	set fd [open "|${potaleaguebin} --register ${call}" r]
+	set fd [open "|${potaleaguebin} --channel ${chan} --register ${call}" r]
 	fconfigure $fd -encoding utf-8
 	while {[gets $fd line] >= 0} {
 		putchan $chan "$line"
@@ -2266,11 +2268,42 @@ proc potaleagueadd_msg {nick uhand handle input} {
 	global potaleaguebin
 	set call [sanitize_string [string trim "${input}"]]
 	putlog "potaleagueadd msg: $nick $uhand $handle $call"
-	if [string equal "" $call] then {
-		putmsg "$nick" "usage: !potaleagueadd <callsign>"
+	if {[string equal "" $call]} then {
+		putmsg "$nick" "usage: !potaleagueadd <callsign> (must be used in a channel)"
 		return
 	}
 	set fd [open "|${potaleaguebin} --register ${call}" r]
+	fconfigure $fd -encoding utf-8
+	while {[gets $fd line] >= 0} {
+		putmsg "$nick" "$line"
+	}
+	close $fd
+}
+
+proc potaleaguedel_pub { nick host hand chan text } {
+	global potaleaguebin
+	set call [sanitize_string [string trim "${text}"]]
+	putlog "potaleaguedel pub: $nick $host $hand $chan $call"
+	if {[string equal "" $call]} then {
+		putchan $chan "usage: !potaleaguedel <callsign>"
+		return
+	}
+	set fd [open "|${potaleaguebin} --channel ${chan} --remove ${call}" r]
+	fconfigure $fd -encoding utf-8
+	while {[gets $fd line] >= 0} {
+		putchan $chan "$line"
+	}
+	close $fd
+}
+proc potaleaguedel_msg {nick uhand handle input} {
+	global potaleaguebin
+	set call [sanitize_string [string trim "${input}"]]
+	putlog "potaleaguedel msg: $nick $uhand $handle $call"
+	if {[string equal "" $call]} then {
+		putmsg "$nick" "usage: !potaleaguedel <callsign> (must be used in a channel)"
+		return
+	}
+	set fd [open "|${potaleaguebin} --remove ${call}" r]
 	fconfigure $fd -encoding utf-8
 	while {[gets $fd line] >= 0} {
 		putmsg "$nick" "$line"

--- a/scripts/qrzgrid.tcl
+++ b/scripts/qrzgrid.tcl
@@ -178,6 +178,13 @@ bind pub - !coax atten_pub
 bind msg - !pota pota_msg
 bind pub - !pota pota_pub
 
+bind msg - !potaleague potaleague_msg
+bind pub - !potaleague potaleague_pub
+bind msg - !potaleagueadd potaleagueadd_msg
+bind pub - !potaleagueadd potaleagueadd_pub
+bind msg - !potaleaguereg potaleagueadd_msg
+bind pub - !potaleaguereg potaleagueadd_pub
+
 bind msg - !potaspots potaspots_msg
 bind pub - !potaspots potaspots_pub
 bind msg - !pspots potaspots_msg
@@ -231,6 +238,7 @@ set blitzbin "/home/eggdrop/bin/blitz"
 set attenbin "/home/eggdrop/bin/atten"
 set potaspotsbin "/home/eggdrop/bin/potaspots"
 set potabin "/home/eggdrop/bin/pota"
+set potaleaguebin "/home/eggdrop/bin/potaleague"
 set sotabin "/home/eggdrop/bin/sota"
 set iotabin "/home/eggdrop/bin/iota"
 set onebyonebin "/home/eggdrop/bin/1x1"
@@ -2207,6 +2215,60 @@ proc fest_msg { nick uhand handle input } {
 	} else {
 		set fd [open "|${festbin} ${loc} --geo ${geo}" r]
 	}
+	fconfigure $fd -encoding utf-8
+	while {[gets $fd line] >= 0} {
+		putmsg "$nick" "$line"
+	}
+	close $fd
+}
+
+proc potaleague_pub { nick host hand chan text } {
+	global potaleaguebin
+	set params [sanitize_string [string trim "${text}"]]
+	putlog "potaleague pub: $nick $host $hand $chan $params"
+	set fd [open "|${potaleaguebin} ${params}" r]
+	fconfigure $fd -encoding utf-8
+	while {[gets $fd line] >= 0} {
+		putchan $chan "$line"
+	}
+	close $fd
+}
+proc potaleague_msg {nick uhand handle input} {
+	global potaleaguebin
+	set params [sanitize_string [string trim "${input}"]]
+	putlog "potaleague msg: $nick $uhand $handle $params"
+	set fd [open "|${potaleaguebin} ${params}" r]
+	fconfigure $fd -encoding utf-8
+	while {[gets $fd line] >= 0} {
+		putmsg "$nick" "$line"
+	}
+	close $fd
+}
+
+proc potaleagueadd_pub { nick host hand chan text } {
+	global potaleaguebin
+	set call [sanitize_string [string trim "${text}"]]
+	putlog "potaleagueadd pub: $nick $host $hand $chan $call"
+	if [string equal "" $call] then {
+		putchan $chan "usage: !potaleagueadd <callsign>"
+		return
+	}
+	set fd [open "|${potaleaguebin} --register ${call}" r]
+	fconfigure $fd -encoding utf-8
+	while {[gets $fd line] >= 0} {
+		putchan $chan "$line"
+	}
+	close $fd
+}
+proc potaleagueadd_msg {nick uhand handle input} {
+	global potaleaguebin
+	set call [sanitize_string [string trim "${input}"]]
+	putlog "potaleagueadd msg: $nick $uhand $handle $call"
+	if [string equal "" $call] then {
+		putmsg "$nick" "usage: !potaleagueadd <callsign>"
+		return
+	}
+	set fd [open "|${potaleaguebin} --register ${call}" r]
 	fconfigure $fd -encoding utf-8
 	while {[gets $fd line] >= 0} {
 		putmsg "$nick" "$line"

--- a/scripts/qrzgrid.tcl
+++ b/scripts/qrzgrid.tcl
@@ -2223,6 +2223,7 @@ proc fest_msg { nick uhand handle input } {
 }
 
 proc potaleague_pub { nick host hand chan text } {
+	if ![string equal "#redditnet" $chan] then { return }
 	global potaleaguebin
 	set params [sanitize_string [string trim "${text}"]]
 	putlog "potaleague pub: $nick $host $hand $chan $params"
@@ -2246,6 +2247,7 @@ proc potaleague_msg {nick uhand handle input} {
 }
 
 proc potaleagueadd_pub { nick host hand chan text } {
+	if ![string equal "#redditnet" $chan] then { return }
 	global potaleaguebin
 	set call [sanitize_string [string trim "${text}"]]
 	putlog "potaleagueadd pub: $nick $host $hand $chan $call"


### PR DESCRIPTION
## Summary

- Adds `!potaleague [year]` — shows the POTA activation leaderboard for the current (or any specified past) year among all registered callsigns, e.g. `POTA League 2026: NV3Y 6A,150Q - W0NY 1A,20Q`
- Adds `!potaleagueadd <callsign>` (also `!potaleaguereg`) — registers a callsign into the league; persists to `$HOME/.qrmbot/potaleague` (one callsign per line)

Activation and QSO counts are pulled live from `api.pota.app/activations/user/<callsign>` and filtered by year, so historical years remain fully queryable as long as POTA retains the data. Leaderboard is sorted by activation count descending, then QSO count.

Follows the same patterns as existing POTA commands (`!pota`, `!potaspots`, `!potapark`): curl + JSON via `decode_json`, `bold()` / `commify()` from Colors/Util, eggdrop-compatible output mode, single IRC line.

## Test plan

- [ ] `!potaleagueadd NV3Y` — should confirm registration
- [ ] `!potaleagueadd NV3Y` again — should report already registered
- [ ] `!potaleague` — should show current-year leaderboard for all registered calls
- [ ] `!potaleague 2025` — should show 2025 leaderboard (historical data from POTA API)
- [ ] `!potaleaguereg W0NY` — alias should work identically to `!potaleagueadd`
- [ ] Private message (`/msg bot !potaleague`) — should work via msg binding
- [ ] No registered callsigns — should print helpful usage message

🤖 Generated with [Claude Code](https://claude.ai/claude-code)