### PR TITLE
potaleague: fix API endpoint

### DIFF
--- a/lib/potaleague
+++ b/lib/potaleague
@@ -10,8 +10,7 @@
 # 2-clause BSD license.
 # Copyright (c) 2026 nreed97@github. All rights reserved.
 
-# https://api.pota.app/activations/user/<callsign>  -- list of all activations
-# https://api.pota.app/profile/<callsign>            -- user profile / stats
+# https://api.pota.app/profile/<callsign>  -- user profile / recent_activity
 
 use URI::Escape;
 use JSON qw( decode_json );
@@ -176,7 +175,7 @@ if (@calls == 0) {
 
 my %stats;
 for my $call (@calls) {
-  my $url = "https://api.pota.app/activations/user/" . uri_escape($call);
+  my $url = "https://api.pota.app/profile/" . uri_escape($call);
 
   local $/;
   open(JSON, '-|', "curl -k -L --max-time 15 --retry 1 -s '$url'");
@@ -184,19 +183,23 @@ for my $call (@calls) {
   close(JSON);
 
   next unless defined $json and $json ne "";
+  next if $json =~ /not found/i;
 
-  my $acts;
-  eval { $acts = decode_json($json); };
+  my $j;
+  eval { $j = decode_json($json); };
   next if $@;
+  next unless ref $j eq 'HASH';
+
+  my $acts = $j->{recent_activity}->{activations};
   next unless ref $acts eq 'ARRAY';
 
   my ($act_count, $qso_count) = (0, 0);
   for my $act (@{$acts}) {
-    my $date = $act->{date} // $act->{qso_date} // "";
+    my $date = $act->{date} // "";
     my $act_year = ($date =~ /^(\d{4})/) ? $1 : "";
     next unless $act_year eq $year;
     $act_count++;
-    $qso_count += $act->{total} // $act->{totalQSOs} // 0;
+    $qso_count += $act->{total} // 0;
   }
 
   $stats{$call} = { activations => $act_count, qsos => $qso_count }


### PR DESCRIPTION
## Summary

- `api.pota.app/activations/user/<callsign>` requires authentication — it returns `{"message":"Missing Authentication Token"}` for unauthenticated callers. This parsed as a hash (not an array), causing every callsign to silently skip, so `!potaleague` always reported no activations.
- Switch to `api.pota.app/profile/<callsign>` and read `recent_activity.activations`, the same public endpoint the existing `!pota` command already uses. Each record has a `date` (YYYY-MM-DD) and `total` field; filter by year to build the leaderboard.

## Test plan

- [ ] `!potaleague` in a channel with registered callsigns now shows activation counts for the current year
- [ ] `!potaleague 2025` shows prior-year data
- [ ] Callsign with no POTA profile (404) is silently skipped
- [ ] Callsign with no activations in the requested year is omitted from output

🤖 Generated with [Claude Code](https://claude.ai/claude-code)