### PR TITLE
potaleague: medal rankings and delimiter fix

### DIFF
--- a/lib/potaleague
+++ b/lib/potaleague
@@ -217,13 +217,17 @@ my @sorted = sort {
     || $stats{$b}{qsos} <=> $stats{$a}{qsos}
 } keys %stats;
 
+my @medals = ("🥇", "🥈", "🥉");
 print "POTA League $year: ";
 my $sep = "";
+my $rank = 1;
 for my $call (@sorted) {
+  my $medal = $rank <= 3 ? $medals[$rank - 1] : "$rank.";
   print $sep;
-  print bold($call) . " "
-      . $stats{$call}{activations} . "A,"
-      . commify($stats{$call}{qsos}) . "Q";
-  $sep = " - ";
+  print "$medal " . bold($call) . " ("
+      . $stats{$call}{activations} . "A; "
+      . commify($stats{$call}{qsos}) . "Q)";
+  $sep = " \x{B7} ";
+  $rank++;
 }
 print "\n";


### PR DESCRIPTION
## Summary

- Add 🥇🥈🥉 medals for top 3, numeric rank (`4.`, `5.`, …) for the rest — matching the style of `!shartleague`
- Separate activation and QSO counts with `; ` instead of `,` to avoid ambiguity when QSO counts are commified (e.g. `20A; 1,175Q` instead of `20A,1,175Q`)
- Use middot (`·`) separator between entries instead of ` - `

Example output:
```
POTA League 2026: 🥇 NV3Y (8A; 384Q) · 🥈 K2IW (5A; 58Q) · 🥉 K2CR (1A; 44Q)
```

## Test plan

- [ ] `!potaleague` shows medals for top 3, numeric rank for 4th+
- [ ] QSO counts with commas (e.g. 1,175) are unambiguous next to activation count
- [ ] Separator between entries renders as middot

🤖 Generated with [Claude Code](https://claude.com/claude-code)