### PR TITLE
potaleague: robust current-year caching with join-date tracking

### DIFF
--- a/lib/potaleague
+++ b/lib/potaleague
@@ -3,15 +3,23 @@
 # POTA yearly league -- !potaleague [year], !potaleagueadd, !potaleaguedel
 #
 # Per-channel registrations persist in $HOME/.qrmbot/db/potaleague
-# (one entry per line: "<channel> <callsign>").
+# (one entry per line: "<channel> <callsign> [join-date]").
 #
-# Activation data is cached in the same file:
-#   ACT   <call> <year> <date> <ref> <total>  -- current year, per-activation
-#   TOTAL <call> <year> <acts> <qsos>         -- past years, collapsed totals
+# Activation data is cached in the same file (current year only):
+#   ACT <call> <year> <date> <ref> <total>
 #
-# Each !potaleague run merges fresh API data into ACT lines.  On every
-# write, ACT lines from past years are collapsed into a single TOTAL line
-# per callsign per year, keeping the file small regardless of history.
+# On every !potaleague run the latest API window (<=25 activations) is merged
+# into ACT lines for the current year.  Past-year data from the API is ignored:
+# the 25-record cap makes historical counts unreliable.
+#
+# For !potaleague <past-year> the live API is queried directly with no caching;
+# output is labelled "(approx)" to reflect the API limit.
+#
+# When a callsign is registered during the current year its join date is stored
+# so the leaderboard can flag entries whose data may be incomplete (i.e. the
+# member had >25 current-year activations before joining the league).
+# Existing registration lines without a join date are treated as legacy and
+# receive no asterisk.
 #
 # 2-clause BSD license.
 # Copyright (c) 2026 nreed97@github. All rights reserved.
@@ -51,9 +59,10 @@ if (not -d $dbdir) {
   }
 }
 
-my $cur_year    = strftime("%Y", gmtime(time()));
-my $year        = $cur_year;
-my $channel     = undef;
+my $cur_year = strftime("%Y", gmtime(time()));
+my $cur_date = strftime("%Y-%m-%d", gmtime(time()));
+my $year     = $cur_year;
+my $channel  = undef;
 my $do_register = 0;
 my $do_remove   = 0;
 my $callsign    = undef;
@@ -93,47 +102,33 @@ sub write_file {
   close($fh);
 }
 
-# Returns (\@regs, \%act_cache, \%totals)
+# Returns (\@regs, \%act_cache)
+#   regs:      raw registration lines ("<channel> <call> [YYYY-MM-DD]")
 #   act_cache: lc("CALL YEAR DATE REF") => { call, year, date, ref, total }
-#   totals:    lc("CALL YEAR")          => { call, year, acts, qsos }
 sub parse_file {
-  my (@regs, %act, %tot);
+  my (@regs, %act);
   for my $line (read_file()) {
     if ($line =~ /^ACT\s+(\S+)\s+(\d{4})\s+(\S+)\s+(\S+)\s+(\d+)$/) {
       my ($call, $yr, $date, $ref, $tot) = (uc $1, $2, $3, $4, $5+0);
       $act{lc "$call $yr $date $ref"} =
         { call => $call, year => $yr, date => $date, ref => $ref, total => $tot };
-    } elsif ($line =~ /^TOTAL\s+(\S+)\s+(\d{4})\s+(\d+)\s+(\d+)$/) {
-      my ($call, $yr, $acts, $qsos) = (uc $1, $2, $3+0, $4+0);
-      $tot{lc "$call $yr"} = { call => $call, year => $yr, acts => $acts, qsos => $qsos };
+    } elsif ($line =~ /^TOTAL\s/) {
+      # legacy line from old caching scheme -- discard silently
     } else {
       push @regs, $line;
     }
   }
-  return (\@regs, \%act, \%tot);
+  return (\@regs, \%act);
 }
 
-# Collapse past-year ACT entries into TOTAL, then write everything out.
+# Write registrations + current-year ACT lines only.
 sub flush_file {
-  my ($regs, $act, $tot) = @_;
-  for my $key (keys %{$act}) {
-    my $e = $act->{$key};
-    next if $e->{year} eq $cur_year;
-    my $tk = lc "$e->{call} $e->{year}";
-    $tot->{$tk} //= { call => $e->{call}, year => $e->{year}, acts => 0, qsos => 0 };
-    $tot->{$tk}{acts}++;
-    $tot->{$tk}{qsos} += $e->{total};
-    delete $act->{$key};
-  }
-  my @tot_lines = map {
-    my $t = $tot->{$_};
-    "TOTAL $t->{call} $t->{year} $t->{acts} $t->{qsos}"
-  } sort keys %{$tot};
+  my ($regs, $act) = @_;
   my @act_lines = map {
     my $e = $act->{$_};
     "ACT $e->{call} $e->{year} $e->{date} $e->{ref} $e->{total}"
-  } sort keys %{$act};
-  write_file(@{$regs}, @tot_lines, @act_lines);
+  } grep { $act->{$_}{year} eq $cur_year } sort keys %{$act};
+  write_file(@{$regs}, @act_lines);
 }
 
 # ── Registration ─────────────────────────────────────────────────────────────
@@ -156,15 +151,14 @@ if ($do_register) {
     exit $exitnonzeroonerror;
   }
 
-  my ($regs, $act, $tot) = parse_file();
-  my $key = "$channel $callsign";
-  if (grep { lc $_ eq lc $key } @{$regs}) {
+  my ($regs, $act) = parse_file();
+  if (grep { my @f = split(' ', $_, 3); lc("$f[0] $f[1]") eq lc("$channel $callsign") } @{$regs}) {
     print bold($callsign) . " is already in the POTA league for $channel\n";
     exit 0;
   }
 
-  push @{$regs}, $key;
-  flush_file($regs, $act, $tot);
+  push @{$regs}, "$channel $callsign $cur_date";
+  flush_file($regs, $act);
   print "registered " . bold($callsign) . " for the POTA league in $channel\n";
   exit 0;
 }
@@ -189,32 +183,45 @@ if ($do_remove) {
     exit $exitnonzeroonerror;
   }
 
-  my ($regs, $act, $tot) = parse_file();
-  my $key = "$channel $callsign";
-  my @updated = grep { lc $_ ne lc $key } @{$regs};
+  my ($regs, $act) = parse_file();
+  my @updated = grep {
+    my @f = split(' ', $_, 3);
+    lc("$f[0] $f[1]") ne lc("$channel $callsign")
+  } @{$regs};
 
   if (@updated == @{$regs}) {
     print bold($callsign) . " is not registered in the POTA league for $channel\n";
     exit 0;
   }
 
-  flush_file(\@updated, $act, $tot);
+  flush_file(\@updated, $act);
   print "removed " . bold($callsign) . " from the POTA league in $channel\n";
   exit 0;
 }
 
 # ── Leaderboard ───────────────────────────────────────────────────────────────
 
-my ($regs, $act, $tot) = parse_file();
+my ($regs, $act) = parse_file();
 
+# Build call list and join-date map for this channel (or all channels).
 my @calls;
+my %reg_join;  # uc(call) => "YYYY-MM-DD" or undef for legacy entries
 if (defined $channel) {
-  @calls = map  { (split ' ', $_, 2)[1] }
-           grep { lc((split ' ', $_, 2)[0]) eq lc($channel) } @{$regs};
+  for my $line (grep { lc((split(' ', $_, 3))[0]) eq lc($channel) } @{$regs}) {
+    my @f = split(' ', $line, 3);
+    my $c = uc $f[1];
+    push @calls, $c;
+    $reg_join{$c} = $f[2];
+  }
 } else {
   my %seen;
-  @calls = grep { !$seen{$_}++ }
-           map  { (split ' ', $_, 2)[1] } @{$regs};
+  for my $line (@{$regs}) {
+    my @f = split(' ', $line, 3);
+    my $c = uc $f[1];
+    next if $seen{$c}++;
+    push @calls, $c;
+    $reg_join{$c} = $f[2];
+  }
 }
 
 if (@calls == 0) {
@@ -223,8 +230,69 @@ if (@calls == 0) {
   exit 0;
 }
 
-# Fetch latest activations and merge into ACT cache
 my %callset = map { lc $_ => 1 } @calls;
+
+my @medals = ("\x{1F947}", "\x{1F948}", "\x{1F949}");
+
+# ── Historical year: live API only, no caching ────────────────────────────────
+
+if ($year ne $cur_year) {
+  my %stats;
+  for my $call (@calls) {
+    my $url = "https://api.pota.app/profile/" . uri_escape($call);
+    local $/;
+    open(JSON, '-|', "curl -k -L --max-time 15 --retry 1 -s '$url'");
+    my $json = <JSON>;
+    close(JSON);
+
+    next unless defined $json and $json ne "";
+    next if $json =~ /not found/i;
+    my $j;
+    eval { $j = decode_json($json); };
+    next if $@;
+    next unless ref $j eq 'HASH';
+
+    my $acts = $j->{recent_activity}{activations};
+    next unless ref $acts eq 'ARRAY';
+
+    for my $a (@{$acts}) {
+      my $date = $a->{date} // "";
+      my ($act_year) = $date =~ /^(\d{4})/;
+      next unless $act_year and $act_year eq $year;
+      $stats{uc $call}{activations}++;
+      $stats{uc $call}{qsos} += $a->{total} // 0;
+    }
+  }
+
+  if (keys %stats == 0) {
+    my $where = defined $channel ? " in $channel" : "";
+    print "no POTA activations found for $year${where} (approx)\n";
+    exit 0;
+  }
+
+  my @sorted = sort {
+    $stats{$b}{activations} <=> $stats{$a}{activations}
+      || $stats{$b}{qsos} <=> $stats{$a}{qsos}
+  } keys %stats;
+
+  print "POTA League $year (approx): ";
+  my $sep = "";
+  my $rank = 1;
+  for my $call (@sorted) {
+    my $medal = $rank <= 3 ? $medals[$rank - 1] : "$rank.";
+    print $sep;
+    print "$medal " . bold($call) . " ("
+        . $stats{$call}{activations} . "A; "
+        . commify($stats{$call}{qsos}) . "Q)";
+    $sep = " \x{B7} ";
+    $rank++;
+  }
+  print "\n";
+  exit 0;
+}
+
+# ── Current year: merge API window into ACT cache ─────────────────────────────
+
 for my $call (@calls) {
   my $url = "https://api.pota.app/profile/" . uri_escape($call);
 
@@ -249,33 +317,23 @@ for my $call (@calls) {
     my $ref  = $a->{reference} // "noref";
     my $tot  = $a->{total} // 0;
     my ($act_year) = $date =~ /^(\d{4})/;
-    next unless $act_year;
-    # Skip past years that already have a collapsed TOTAL -- adding them
-    # again would double-count once flush merges ACT into the existing TOTAL.
-    next if $act_year ne $cur_year and exists $tot->{lc "$call $act_year"};
+    next unless $act_year and $act_year eq $cur_year;
     my $cachekey = lc "$call $act_year $date $ref";
     $act->{$cachekey} //=
       { call => uc $call, year => $act_year, date => $date, ref => $ref, total => $tot };
   }
 }
 
-# Persist: collapses past-year ACT → TOTAL, writes everything
-flush_file($regs, $act, $tot);
+flush_file($regs, $act);
 
-# Compute leaderboard from ACT cache (current year) + TOTAL (historical)
+# ── Build leaderboard from ACT cache ─────────────────────────────────────────
+
 my %stats;
 for my $e (values %{$act}) {
-  next unless $e->{year} eq $year;
+  next unless $e->{year} eq $cur_year;
   next unless $callset{lc $e->{call}};
   $stats{uc $e->{call}}{activations}++;
   $stats{uc $e->{call}}{qsos} += $e->{total};
-}
-for my $t (values %{$tot}) {
-  next unless $t->{year} eq $year;
-  next unless $callset{lc $t->{call}};
-  my $call = uc $t->{call};
-  $stats{$call}{activations} = ($stats{$call}{activations} // 0) + $t->{acts};
-  $stats{$call}{qsos}        = ($stats{$call}{qsos}        // 0) + $t->{qsos};
 }
 
 if (keys %stats == 0) {
@@ -284,22 +342,36 @@ if (keys %stats == 0) {
   exit 0;
 }
 
+# Flag callsigns whose join date falls within the current year -- their cached
+# count is a floor, not a ceiling (earlier activations may not have been seen).
+my %incomplete;
+for my $call (keys %stats) {
+  my $jd = $reg_join{$call};
+  next unless defined $jd;
+  my ($jy) = $jd =~ /^(\d{4})/;
+  $incomplete{$call} = 1 if defined $jy and $jy eq $cur_year;
+}
+
 my @sorted = sort {
   $stats{$b}{activations} <=> $stats{$a}{activations}
     || $stats{$b}{qsos} <=> $stats{$a}{qsos}
 } keys %stats;
 
-my @medals = ("🥇", "🥈", "🥉");
 print "POTA League $year: ";
 my $sep = "";
 my $rank = 1;
+my $any_incomplete = 0;
 for my $call (@sorted) {
   my $medal = $rank <= 3 ? $medals[$rank - 1] : "$rank.";
+  my $flag  = $incomplete{$call} ? "*" : "";
+  $any_incomplete = 1 if $flag;
   print $sep;
-  print "$medal " . bold($call) . " ("
+  print "$medal " . bold($call) . "$flag ("
       . $stats{$call}{activations} . "A; "
       . commify($stats{$call}{qsos}) . "Q)";
   $sep = " \x{B7} ";
   $rank++;
 }
 print "\n";
+print "* data tracked from join date; earlier activations not captured\n"
+  if $any_incomplete;

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -107,10 +107,12 @@ sub parse_file {
 
 sub flush_file {
   my ($regs, $cache) = @_;
+  my $cur_year  = strftime("%Y", gmtime(time()));
+  my $keep_from = $cur_year - 1;
   my @cache_lines = map {
     my $e = $cache->{$_};
     "ACT $e->{call} $e->{year} $e->{date} $e->{ref} $e->{total}"
-  } sort keys %{$cache};
+  } grep { $cache->{$_}{year} >= $keep_from } sort keys %{$cache};
   write_file(@{$regs}, @cache_lines);
 }
 

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -12,12 +12,11 @@
 # 2-clause BSD license.
 # Copyright (c) 2026 nreed97@github. All rights reserved.
 
-# https://cognito-idp.us-east-2.amazonaws.com/      -- Cognito auth, returns JWT
 # https://api.pota.app/activations/user/<callsign>  -- full history (auth req'd)
 # https://api.pota.app/profile/<callsign>           -- public, last 25 only
 
 use URI::Escape;
-use JSON qw( decode_json encode_json );
+use JSON qw( decode_json );
 use strict;
 use utf8;
 use feature 'unicode_strings';
@@ -25,7 +24,6 @@ use Encode qw(decode);
 binmode(STDOUT, ":utf8");
 
 use File::Basename;
-use File::Temp qw(tempfile);
 use Cwd 'realpath';
 use lib dirname(realpath(__FILE__));
 use Colors;
@@ -161,45 +159,19 @@ if ($do_remove) {
 }
 
 # ── Auth ──────────────────────────────────────────────────────────────────────
+# TOKEN in $credsfile is a POTA JWT, obtained from the browser:
+#   document.querySelector('#app').__vue__.$store.state.user.token
+# Paste the result into $HOME/.qrmbot/creds/pota as: TOKEN=eyJ...
+# Refresh it manually when it expires (~30 days).
 
-my ($pota_user, $pota_pass);
+my $auth_token;
 if (-f $credsfile) {
   open(my $cfh, '<', $credsfile) or die "cannot open $credsfile: $!";
   while (<$cfh>) {
     chomp;
-    if (/^POTA_USER\s*=\s*(.+)$/) { $pota_user = $1; }
-    if (/^POTA_PASS\s*=\s*(.+)$/) { $pota_pass = $1; }
+    if (/^TOKEN\s*=\s*(.+)$/) { $auth_token = $1; last; }
   }
   close($cfh);
-}
-
-my $auth_token;
-if (defined $pota_user and defined $pota_pass) {
-  my $auth_url  = 'https://cognito-idp.us-east-2.amazonaws.com/';
-  my $auth_body = encode_json({
-    AuthFlow       => 'USER_PASSWORD_AUTH',
-    AuthParameters => { USERNAME => $pota_user, PASSWORD => $pota_pass },
-    ClientId       => '7hluqct0n2nckib7i7sd5753oa',
-  });
-  my ($tmp_fh, $tmp_name) = tempfile(UNLINK => 1);
-  print $tmp_fh $auth_body;
-  close($tmp_fh);
-
-  local $/;
-  open(my $afh, '-|', "curl -k -L --max-time 15 -s -X POST '$auth_url'"
-                    . " -H 'Content-Type: application/x-amz-json-1.1'"
-                    . " -H 'X-Amz-Target: AWSCognitoIdentityProviderService.InitiateAuth'"
-                    . " --data-binary \@$tmp_name");
-  my $auth_json = <$afh>;
-  close($afh);
-
-  if (defined $auth_json and $auth_json ne "") {
-    my $aj;
-    eval { $aj = decode_json($auth_json); };
-    unless ($@) {
-      $auth_token = $aj->{AuthenticationResult}{IdToken};
-    }
-  }
 }
 
 # ── Leaderboard ───────────────────────────────────────────────────────────────

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -2,29 +2,73 @@
 #
 # POTA yearly league -- !potaleague [year], !potaleagueadd, !potaleaguedel
 #
-# Per-channel registrations persist in $HOME/.qrmbot/db/potaleague
-# (one entry per line: "<channel> <callsign> [join-date]").
+# ── API constraint ────────────────────────────────────────────────────────────
+# The public POTA API endpoint used here:
+#   https://api.pota.app/profile/<callsign>
+# returns only the 25 most-recent activations across all time.  There is no
+# public endpoint that returns another user's full activation history.
+# Authenticated endpoints (requiring a JWT from the POTA web app) exist but
+# return HTTP 403 for arbitrary callsigns -- they are restricted to the
+# authenticated user's own data or admin access.  Accordingly, complete
+# historical data for other callsigns is simply not available.
 #
-# Activation data is cached in the same file (current year only):
-#   ACT <call> <year> <date> <ref> <total>
+# ── Persistence file ($HOME/.qrmbot/db/potaleague) ───────────────────────────
+# Two kinds of records share the same file:
 #
-# On every !potaleague run the latest API window (<=25 activations) is merged
-# into ACT lines for the current year.  Past-year data from the API is ignored:
-# the 25-record cap makes historical counts unreliable.
+#   Registration lines (one per registered callsign per channel):
+#     <channel> <callsign> [YYYY-MM-DD]
+#   The optional date is the day the callsign was added to the league.
+#   It is recorded so the leaderboard can flag members who joined mid-year
+#   (see "New member problem" below).  Legacy entries without a date are
+#   treated as always-tracked and receive no flag.
 #
-# For !potaleague <past-year> the live API is queried directly with no caching;
-# output is labelled "(approx)" to reflect the API limit.
+#   Activation cache lines (current year only):
+#     ACT <call> <year> <date> <ref> <total>
+#   Each line represents one park activation: callsign, year, activation date,
+#   park reference (e.g. US-1234), and total QSO count for that activation.
+#   Cache keys are lc("CALL YEAR DATE REF"), so duplicate API responses for
+#   the same activation are silently deduplicated (//= never overwrites).
 #
-# When a callsign is registered during the current year its join date is stored
-# so the leaderboard can flag entries whose data may be incomplete (i.e. the
-# member had >25 current-year activations before joining the league).
-# Existing registration lines without a join date are treated as legacy and
-# receive no asterisk.
+# ── Current-year caching strategy ────────────────────────────────────────────
+# On every !potaleague run the script fetches the live API window (<=25
+# activations) for each registered callsign and merges any current-year
+# records into the ACT cache.  Past-year records returned by the API are
+# silently ignored.
+#
+# This approach accumulates an accurate picture of the current year as long
+# as !potaleague is run at least once within any member's 25-activation
+# rolling window.  Because the cache only grows (never overwrites), counts
+# are monotonically non-decreasing -- a member's total will never go
+# backwards between runs.
+#
+# Historical caching (collapsing past-year ACT lines into summary TOTAL
+# lines) was deliberately removed.  The 25-record cap means a callsign
+# whose recent API window is dominated by current-year activations would
+# show zero for a prior year even if they were highly active then -- wrong
+# data is worse than no data.  Old TOTAL lines from any previous version of
+# this script are silently discarded on first read.
+#
+# ── Historical year queries (!potaleague 2025) ────────────────────────────────
+# When a year other than the current one is requested, the live API is queried
+# directly for each callsign and filtered to the requested year.  No data is
+# written to the cache file.  Output is labelled "(approx)" to be honest that
+# the counts reflect only the activations that happen to fall within the
+# 25-record window at the time of the query.
+#
+# ── New member problem and join-date flag ─────────────────────────────────────
+# A member registered mid-year with more than 25 current-year activations
+# already on record will always have an undercount -- the first API seed
+# captures at most 25, and the earlier ones are permanently out of reach.
+#
+# To communicate this honestly the leaderboard appends "*" to any callsign
+# whose stored join date falls within the current year, and prints a footnote:
+#   * data tracked from join date; earlier activations not captured
+# The asterisk means "this is a floor, not a ceiling."  Callsigns with no
+# stored join date (legacy registrations) receive no asterisk because they
+# were presumably tracked from the start of the year.
 #
 # 2-clause BSD license.
 # Copyright (c) 2026 nreed97@github. All rights reserved.
-
-# https://api.pota.app/profile/<callsign>  -- user profile / recent_activity
 
 use URI::Escape;
 use JSON qw( decode_json );

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -5,11 +5,13 @@
 # Per-channel registrations persist in $HOME/.qrmbot/db/potaleague
 # (one entry per line: "<channel> <callsign>").
 #
-# Activation data is cached in the same file as ACT lines:
-#   ACT <callsign> <year> <date> <reference> <total>
-# Each !potaleague run merges the latest API results into the cache so
-# that activations are accumulated over time, working around the public
-# API's 25-record limit.
+# Activation data is cached in the same file:
+#   ACT   <call> <year> <date> <ref> <total>  -- current year, per-activation
+#   TOTAL <call> <year> <acts> <qsos>         -- past years, collapsed totals
+#
+# Each !potaleague run merges fresh API data into ACT lines.  On every
+# write, ACT lines from past years are collapsed into a single TOTAL line
+# per callsign per year, keeping the file small regardless of history.
 #
 # 2-clause BSD license.
 # Copyright (c) 2026 nreed97@github. All rights reserved.
@@ -49,7 +51,8 @@ if (not -d $dbdir) {
   }
 }
 
-my $year        = strftime("%Y", gmtime(time()));
+my $cur_year    = strftime("%Y", gmtime(time()));
+my $year        = $cur_year;
 my $channel     = undef;
 my $do_register = 0;
 my $do_remove   = 0;
@@ -90,30 +93,47 @@ sub write_file {
   close($fh);
 }
 
+# Returns (\@regs, \%act_cache, \%totals)
+#   act_cache: lc("CALL YEAR DATE REF") => { call, year, date, ref, total }
+#   totals:    lc("CALL YEAR")          => { call, year, acts, qsos }
 sub parse_file {
-  my @regs;
-  my %cache;  # lc("CALL YEAR DATE REF") => { call, year, date, ref, total }
+  my (@regs, %act, %tot);
   for my $line (read_file()) {
     if ($line =~ /^ACT\s+(\S+)\s+(\d{4})\s+(\S+)\s+(\S+)\s+(\d+)$/) {
       my ($call, $yr, $date, $ref, $tot) = (uc $1, $2, $3, $4, $5+0);
-      $cache{lc "$call $yr $date $ref"} =
+      $act{lc "$call $yr $date $ref"} =
         { call => $call, year => $yr, date => $date, ref => $ref, total => $tot };
+    } elsif ($line =~ /^TOTAL\s+(\S+)\s+(\d{4})\s+(\d+)\s+(\d+)$/) {
+      my ($call, $yr, $acts, $qsos) = (uc $1, $2, $3+0, $4+0);
+      $tot{lc "$call $yr"} = { call => $call, year => $yr, acts => $acts, qsos => $qsos };
     } else {
       push @regs, $line;
     }
   }
-  return (\@regs, \%cache);
+  return (\@regs, \%act, \%tot);
 }
 
+# Collapse past-year ACT entries into TOTAL, then write everything out.
 sub flush_file {
-  my ($regs, $cache) = @_;
-  my $cur_year  = strftime("%Y", gmtime(time()));
-  my $keep_from = $cur_year - 1;
-  my @cache_lines = map {
-    my $e = $cache->{$_};
+  my ($regs, $act, $tot) = @_;
+  for my $key (keys %{$act}) {
+    my $e = $act->{$key};
+    next if $e->{year} eq $cur_year;
+    my $tk = lc "$e->{call} $e->{year}";
+    $tot->{$tk} //= { call => $e->{call}, year => $e->{year}, acts => 0, qsos => 0 };
+    $tot->{$tk}{acts}++;
+    $tot->{$tk}{qsos} += $e->{total};
+    delete $act->{$key};
+  }
+  my @tot_lines = map {
+    my $t = $tot->{$_};
+    "TOTAL $t->{call} $t->{year} $t->{acts} $t->{qsos}"
+  } sort keys %{$tot};
+  my @act_lines = map {
+    my $e = $act->{$_};
     "ACT $e->{call} $e->{year} $e->{date} $e->{ref} $e->{total}"
-  } grep { $cache->{$_}{year} >= $keep_from } sort keys %{$cache};
-  write_file(@{$regs}, @cache_lines);
+  } sort keys %{$act};
+  write_file(@{$regs}, @tot_lines, @act_lines);
 }
 
 # ── Registration ─────────────────────────────────────────────────────────────
@@ -136,7 +156,7 @@ if ($do_register) {
     exit $exitnonzeroonerror;
   }
 
-  my ($regs, $cache) = parse_file();
+  my ($regs, $act, $tot) = parse_file();
   my $key = "$channel $callsign";
   if (grep { lc $_ eq lc $key } @{$regs}) {
     print bold($callsign) . " is already in the POTA league for $channel\n";
@@ -144,7 +164,7 @@ if ($do_register) {
   }
 
   push @{$regs}, $key;
-  flush_file($regs, $cache);
+  flush_file($regs, $act, $tot);
   print "registered " . bold($callsign) . " for the POTA league in $channel\n";
   exit 0;
 }
@@ -169,7 +189,7 @@ if ($do_remove) {
     exit $exitnonzeroonerror;
   }
 
-  my ($regs, $cache) = parse_file();
+  my ($regs, $act, $tot) = parse_file();
   my $key = "$channel $callsign";
   my @updated = grep { lc $_ ne lc $key } @{$regs};
 
@@ -178,14 +198,14 @@ if ($do_remove) {
     exit 0;
   }
 
-  flush_file(\@updated, $cache);
+  flush_file(\@updated, $act, $tot);
   print "removed " . bold($callsign) . " from the POTA league in $channel\n";
   exit 0;
 }
 
 # ── Leaderboard ───────────────────────────────────────────────────────────────
 
-my ($regs, $cache) = parse_file();
+my ($regs, $act, $tot) = parse_file();
 
 my @calls;
 if (defined $channel) {
@@ -203,7 +223,7 @@ if (@calls == 0) {
   exit 0;
 }
 
-# Fetch latest activations and merge into cache
+# Fetch latest activations and merge into ACT cache
 my %callset = map { lc $_ => 1 } @calls;
 for my $call (@calls) {
   my $url = "https://api.pota.app/profile/" . uri_escape($call);
@@ -224,28 +244,38 @@ for my $call (@calls) {
   my $acts = $j->{recent_activity}{activations};
   next unless ref $acts eq 'ARRAY';
 
-  for my $act (@{$acts}) {
-    my $date = $act->{date} // "";
-    my $ref  = $act->{reference} // "noref";
-    my $tot  = $act->{total} // 0;
+  for my $a (@{$acts}) {
+    my $date = $a->{date} // "";
+    my $ref  = $a->{reference} // "noref";
+    my $tot  = $a->{total} // 0;
     my ($act_year) = $date =~ /^(\d{4})/;
     next unless $act_year;
+    # Skip past years that already have a collapsed TOTAL -- adding them
+    # again would double-count once flush merges ACT into the existing TOTAL.
+    next if $act_year ne $cur_year and exists $tot->{lc "$call $act_year"};
     my $cachekey = lc "$call $act_year $date $ref";
-    $cache->{$cachekey} //=
+    $act->{$cachekey} //=
       { call => uc $call, year => $act_year, date => $date, ref => $ref, total => $tot };
   }
 }
 
-# Persist updated cache
-flush_file($regs, $cache);
+# Persist: collapses past-year ACT → TOTAL, writes everything
+flush_file($regs, $act, $tot);
 
-# Compute leaderboard from full cache for the requested year
+# Compute leaderboard from ACT cache (current year) + TOTAL (historical)
 my %stats;
-for my $e (values %{$cache}) {
+for my $e (values %{$act}) {
   next unless $e->{year} eq $year;
   next unless $callset{lc $e->{call}};
   $stats{uc $e->{call}}{activations}++;
   $stats{uc $e->{call}}{qsos} += $e->{total};
+}
+for my $t (values %{$tot}) {
+  next unless $t->{year} eq $year;
+  next unless $callset{lc $t->{call}};
+  my $call = uc $t->{call};
+  $stats{$call}{activations} = ($stats{$call}{activations} // 0) + $t->{acts};
+  $stats{$call}{qsos}        = ($stats{$call}{qsos}        // 0) + $t->{qsos};
 }
 
 if (keys %stats == 0) {

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -12,7 +12,7 @@
 # 2-clause BSD license.
 # Copyright (c) 2026 nreed97@github. All rights reserved.
 
-# https://api.pota.app/auth/                        -- login, returns JWT
+# https://cognito-idp.us-east-2.amazonaws.com/      -- Cognito auth, returns JWT
 # https://api.pota.app/activations/user/<callsign>  -- full history (auth req'd)
 # https://api.pota.app/profile/<callsign>           -- public, last 25 only
 
@@ -175,15 +175,20 @@ if (-f $credsfile) {
 
 my $auth_token;
 if (defined $pota_user and defined $pota_pass) {
-  my $auth_url  = 'https://api.pota.app/auth/';
-  my $auth_body = encode_json({ userId => $pota_user, password => $pota_pass });
+  my $auth_url  = 'https://cognito-idp.us-east-2.amazonaws.com/';
+  my $auth_body = encode_json({
+    AuthFlow       => 'USER_PASSWORD_AUTH',
+    AuthParameters => { USERNAME => $pota_user, PASSWORD => $pota_pass },
+    ClientId       => '7hluqct0n2nckib7i7sd5753oa',
+  });
   my ($tmp_fh, $tmp_name) = tempfile(UNLINK => 1);
   print $tmp_fh $auth_body;
   close($tmp_fh);
 
   local $/;
   open(my $afh, '-|', "curl -k -L --max-time 15 -s -X POST '$auth_url'"
-                    . " -H 'Content-Type: application/json'"
+                    . " -H 'Content-Type: application/x-amz-json-1.1'"
+                    . " -H 'X-Amz-Target: AWSCognitoIdentityProviderService.InitiateAuth'"
                     . " --data-binary \@$tmp_name");
   my $auth_json = <$afh>;
   close($afh);
@@ -192,9 +197,7 @@ if (defined $pota_user and defined $pota_pass) {
     my $aj;
     eval { $aj = decode_json($auth_json); };
     unless ($@) {
-      $auth_token = $aj->{AuthenticationResult}{IdToken}
-                 // $aj->{token}
-                 // $aj->{access_token};
+      $auth_token = $aj->{AuthenticationResult}{IdToken};
     }
   }
 }

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -4,7 +4,12 @@
 #
 # Per-channel registrations persist in $HOME/.qrmbot/db/potaleague
 # (one entry per line: "<channel> <callsign>").
-# Activation and QSO counts are fetched live from the POTA API.
+#
+# Activation data is cached in the same file as ACT lines:
+#   ACT <callsign> <year> <date> <reference> <total>
+# Each !potaleague run merges the latest API results into the cache so
+# that activations are accumulated over time, working around the public
+# API's 25-record limit.
 #
 # 2-clause BSD license.
 # Copyright (c) 2026 nreed97@github. All rights reserved.
@@ -71,19 +76,42 @@ while ($i <= $#ARGV) {
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
-sub read_entries {
-  my @entries = ();
-  return @entries unless -f $leaguefile;
+sub read_file {
+  return () unless -f $leaguefile;
   open(my $fh, '<', $leaguefile) or die "cannot open $leaguefile: $!";
-  while (<$fh>) { chomp; push @entries, $_ if length $_ > 0; }
+  my @lines = grep { length $_ > 0 } map { chomp; $_ } <$fh>;
   close($fh);
-  return @entries;
+  return @lines;
 }
 
-sub write_entries {
+sub write_file {
   open(my $fh, '>', $leaguefile) or die "cannot write $leaguefile: $!";
   print $fh "$_\n" for @_;
   close($fh);
+}
+
+sub parse_file {
+  my @regs;
+  my %cache;  # lc("CALL YEAR DATE REF") => { call, year, date, ref, total }
+  for my $line (read_file()) {
+    if ($line =~ /^ACT\s+(\S+)\s+(\d{4})\s+(\S+)\s+(\S+)\s+(\d+)$/) {
+      my ($call, $yr, $date, $ref, $tot) = (uc $1, $2, $3, $4, $5+0);
+      $cache{lc "$call $yr $date $ref"} =
+        { call => $call, year => $yr, date => $date, ref => $ref, total => $tot };
+    } else {
+      push @regs, $line;
+    }
+  }
+  return (\@regs, \%cache);
+}
+
+sub flush_file {
+  my ($regs, $cache) = @_;
+  my @cache_lines = map {
+    my $e = $cache->{$_};
+    "ACT $e->{call} $e->{year} $e->{date} $e->{ref} $e->{total}"
+  } sort keys %{$cache};
+  write_file(@{$regs}, @cache_lines);
 }
 
 # ── Registration ─────────────────────────────────────────────────────────────
@@ -106,15 +134,15 @@ if ($do_register) {
     exit $exitnonzeroonerror;
   }
 
-  my @existing = read_entries();
+  my ($regs, $cache) = parse_file();
   my $key = "$channel $callsign";
-  if (grep { lc $_ eq lc $key } @existing) {
+  if (grep { lc $_ eq lc $key } @{$regs}) {
     print bold($callsign) . " is already in the POTA league for $channel\n";
     exit 0;
   }
 
-  push @existing, $key;
-  write_entries(@existing);
+  push @{$regs}, $key;
+  flush_file($regs, $cache);
   print "registered " . bold($callsign) . " for the POTA league in $channel\n";
   exit 0;
 }
@@ -139,31 +167,32 @@ if ($do_remove) {
     exit $exitnonzeroonerror;
   }
 
-  my @existing = read_entries();
+  my ($regs, $cache) = parse_file();
   my $key = "$channel $callsign";
-  my @updated = grep { lc $_ ne lc $key } @existing;
+  my @updated = grep { lc $_ ne lc $key } @{$regs};
 
-  if (@updated == @existing) {
+  if (@updated == @{$regs}) {
     print bold($callsign) . " is not registered in the POTA league for $channel\n";
     exit 0;
   }
 
-  write_entries(@updated);
+  flush_file(\@updated, $cache);
   print "removed " . bold($callsign) . " from the POTA league in $channel\n";
   exit 0;
 }
 
 # ── Leaderboard ───────────────────────────────────────────────────────────────
 
-my @entries = read_entries();
+my ($regs, $cache) = parse_file();
+
 my @calls;
 if (defined $channel) {
   @calls = map  { (split ' ', $_, 2)[1] }
-           grep { lc((split ' ', $_, 2)[0]) eq lc($channel) } @entries;
+           grep { lc((split ' ', $_, 2)[0]) eq lc($channel) } @{$regs};
 } else {
   my %seen;
   @calls = grep { !$seen{$_}++ }
-           map  { (split ' ', $_, 2)[1] } @entries;
+           map  { (split ' ', $_, 2)[1] } @{$regs};
 }
 
 if (@calls == 0) {
@@ -172,7 +201,8 @@ if (@calls == 0) {
   exit 0;
 }
 
-my %stats;
+# Fetch latest activations and merge into cache
+my %callset = map { lc $_ => 1 } @calls;
 for my $call (@calls) {
   my $url = "https://api.pota.app/profile/" . uri_escape($call);
 
@@ -192,17 +222,28 @@ for my $call (@calls) {
   my $acts = $j->{recent_activity}{activations};
   next unless ref $acts eq 'ARRAY';
 
-  my ($act_count, $qso_count) = (0, 0);
   for my $act (@{$acts}) {
-    my $date     = $act->{date} // "";
-    my $act_year = ($date =~ /^(\d{4})/) ? $1 : "";
-    next unless $act_year eq $year;
-    $act_count++;
-    $qso_count += $act->{total} // 0;
+    my $date = $act->{date} // "";
+    my $ref  = $act->{reference} // "noref";
+    my $tot  = $act->{total} // 0;
+    my ($act_year) = $date =~ /^(\d{4})/;
+    next unless $act_year;
+    my $cachekey = lc "$call $act_year $date $ref";
+    $cache->{$cachekey} //=
+      { call => uc $call, year => $act_year, date => $date, ref => $ref, total => $tot };
   }
+}
 
-  $stats{$call} = { activations => $act_count, qsos => $qso_count }
-    if $act_count > 0;
+# Persist updated cache
+flush_file($regs, $cache);
+
+# Compute leaderboard from full cache for the requested year
+my %stats;
+for my $e (values %{$cache}) {
+  next unless $e->{year} eq $year;
+  next unless $callset{lc $e->{call}};
+  $stats{uc $e->{call}}{activations}++;
+  $stats{uc $e->{call}}{qsos} += $e->{total};
 }
 
 if (keys %stats == 0) {

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -4,16 +4,20 @@
 #
 # Per-channel registrations persist in $HOME/.qrmbot/db/potaleague
 # (one entry per line: "<channel> <callsign>").
-# Activation and QSO counts are fetched live from the POTA API, so any
-# calendar year can be queried as long as POTA retains the history.
+# Activation and QSO counts are fetched live from the POTA API.
+# If $HOME/.qrmbot/creds/pota contains POTA_USER and POTA_PASS, the
+# authenticated API is used (full history); otherwise falls back to the
+# public profile API (last 25 activations only).
 #
 # 2-clause BSD license.
 # Copyright (c) 2026 nreed97@github. All rights reserved.
 
-# https://api.pota.app/profile/<callsign>  -- user profile / recent_activity
+# https://api.pota.app/auth/                        -- login, returns JWT
+# https://api.pota.app/activations/user/<callsign>  -- full history (auth req'd)
+# https://api.pota.app/profile/<callsign>           -- public, last 25 only
 
 use URI::Escape;
-use JSON qw( decode_json );
+use JSON qw( decode_json encode_json );
 use strict;
 use utf8;
 use feature 'unicode_strings';
@@ -21,6 +25,7 @@ use Encode qw(decode);
 binmode(STDOUT, ":utf8");
 
 use File::Basename;
+use File::Temp qw(tempfile);
 use Cwd 'realpath';
 use lib dirname(realpath(__FILE__));
 use Colors;
@@ -36,6 +41,7 @@ $exitnonzeroonerror = 0 if $username eq getEggdropUID();
 
 my $dbdir      = $ENV{'HOME'} . "/.qrmbot/db";
 my $leaguefile = "$dbdir/potaleague";
+my $credsfile  = $ENV{'HOME'} . "/.qrmbot/creds/pota";
 
 if (not -d $dbdir) {
   print "making db directory..\n";
@@ -154,6 +160,45 @@ if ($do_remove) {
   exit 0;
 }
 
+# ── Auth ──────────────────────────────────────────────────────────────────────
+
+my ($pota_user, $pota_pass);
+if (-f $credsfile) {
+  open(my $cfh, '<', $credsfile) or die "cannot open $credsfile: $!";
+  while (<$cfh>) {
+    chomp;
+    if (/^POTA_USER\s*=\s*(.+)$/) { $pota_user = $1; }
+    if (/^POTA_PASS\s*=\s*(.+)$/) { $pota_pass = $1; }
+  }
+  close($cfh);
+}
+
+my $auth_token;
+if (defined $pota_user and defined $pota_pass) {
+  my $auth_url  = 'https://api.pota.app/auth/';
+  my $auth_body = encode_json({ userId => $pota_user, password => $pota_pass });
+  my ($tmp_fh, $tmp_name) = tempfile(UNLINK => 1);
+  print $tmp_fh $auth_body;
+  close($tmp_fh);
+
+  local $/;
+  open(my $afh, '-|', "curl -k -L --max-time 15 -s -X POST '$auth_url'"
+                    . " -H 'Content-Type: application/json'"
+                    . " --data-binary \@$tmp_name");
+  my $auth_json = <$afh>;
+  close($afh);
+
+  if (defined $auth_json and $auth_json ne "") {
+    my $aj;
+    eval { $aj = decode_json($auth_json); };
+    unless ($@) {
+      $auth_token = $aj->{AuthenticationResult}{IdToken}
+                 // $aj->{token}
+                 // $aj->{access_token};
+    }
+  }
+}
+
 # ── Leaderboard ───────────────────────────────────────────────────────────────
 
 my @entries = read_entries();
@@ -175,31 +220,47 @@ if (@calls == 0) {
 
 my %stats;
 for my $call (@calls) {
-  my $url = "https://api.pota.app/profile/" . uri_escape($call);
+  my $acts_ref;
 
-  local $/;
-  open(JSON, '-|', "curl -k -L --max-time 15 --retry 1 -s '$url'");
-  my $json = <JSON>;
-  close(JSON);
+  if (defined $auth_token) {
+    my $url = "https://api.pota.app/activations/user/" . uri_escape($call);
+    local $/;
+    open(JSON, '-|', "curl -k -L --max-time 15 --retry 1 -s"
+                   . " -H 'Authorization: $auth_token' '$url'");
+    my $json = <JSON>;
+    close(JSON);
+    if (defined $json and $json ne "") {
+      my $j;
+      eval { $j = decode_json($json); };
+      $acts_ref = $j if !$@ and ref $j eq 'ARRAY';
+    }
+  }
 
-  next unless defined $json and $json ne "";
-  next if $json =~ /not found/i;
+  unless (defined $acts_ref) {
+    # fallback: public profile API, last 25 activations only
+    my $url = "https://api.pota.app/profile/" . uri_escape($call);
+    local $/;
+    open(JSON, '-|', "curl -k -L --max-time 15 --retry 1 -s '$url'");
+    my $json = <JSON>;
+    close(JSON);
+    next unless defined $json and $json ne "";
+    next if $json =~ /not found/i;
+    my $j;
+    eval { $j = decode_json($json); };
+    next if $@;
+    next unless ref $j eq 'HASH';
+    $acts_ref = $j->{recent_activity}{activations};
+  }
 
-  my $j;
-  eval { $j = decode_json($json); };
-  next if $@;
-  next unless ref $j eq 'HASH';
-
-  my $acts = $j->{recent_activity}->{activations};
-  next unless ref $acts eq 'ARRAY';
+  next unless ref $acts_ref eq 'ARRAY';
 
   my ($act_count, $qso_count) = (0, 0);
-  for my $act (@{$acts}) {
-    my $date = $act->{date} // "";
+  for my $act (@{$acts_ref}) {
+    my $date     = $act->{date} // "";
     my $act_year = ($date =~ /^(\d{4})/) ? $1 : "";
     next unless $act_year eq $year;
     $act_count++;
-    $qso_count += $act->{total} // 0;
+    $qso_count += $act->{totalQSOs} // $act->{total} // 0;
   }
 
   $stats{$call} = { activations => $act_count, qsos => $qso_count }
@@ -217,13 +278,17 @@ my @sorted = sort {
     || $stats{$b}{qsos} <=> $stats{$a}{qsos}
 } keys %stats;
 
+my @medals = ("🥇", "🥈", "🥉");
 print "POTA League $year: ";
 my $sep = "";
+my $rank = 1;
 for my $call (@sorted) {
+  my $medal = $rank <= 3 ? $medals[$rank - 1] : "$rank.";
   print $sep;
-  print bold($call) . " "
-      . $stats{$call}{activations} . "A,"
-      . commify($stats{$call}{qsos}) . "Q";
-  $sep = " - ";
+  print "$medal " . bold($call) . " ("
+      . $stats{$call}{activations} . "A; "
+      . commify($stats{$call}{qsos}) . "Q)";
+  $sep = " \x{B7} ";
+  $rank++;
 }
 print "\n";

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -196,8 +196,29 @@ if ($do_register) {
   }
 
   my ($regs, $act) = parse_file();
-  if (grep { my @f = split(' ', $_, 3); lc("$f[0] $f[1]") eq lc("$channel $callsign") } @{$regs}) {
+
+  # Active (non-deleted) duplicate check
+  if (grep { !/^DEL\s/ && do { my @f = split(' ', $_, 3); lc("$f[0] $f[1]") eq lc("$channel $callsign") } } @{$regs}) {
     print bold($callsign) . " is already in the POTA league for $channel\n";
+    exit 0;
+  }
+
+  # Restore a soft-deleted entry, preserving original join date and ACT cache
+  my $restored = 0;
+  for my $r (@{$regs}) {
+    if ($r =~ /^DEL\s/) {
+      my @f = split(' ', $r, 4);  # DEL, channel, callsign, [date]
+      if (lc("$f[1] $f[2]") eq lc("$channel $callsign")) {
+        $r =~ s/^DEL\s+//;
+        $restored = 1;
+        last;
+      }
+    }
+  }
+
+  if ($restored) {
+    flush_file($regs, $act);
+    print "restored " . bold($callsign) . " to the POTA league in $channel (historical data preserved)\n";
     exit 0;
   }
 
@@ -228,17 +249,25 @@ if ($do_remove) {
   }
 
   my ($regs, $act) = parse_file();
-  my @updated = grep {
-    my @f = split(' ', $_, 3);
-    lc("$f[0] $f[1]") ne lc("$channel $callsign")
-  } @{$regs};
 
-  if (@updated == @{$regs}) {
+  # Soft-delete: mark inactive so ACT cache is preserved for restore
+  my $found = 0;
+  for my $r (@{$regs}) {
+    next if $r =~ /^DEL\s/;
+    my @f = split(' ', $r, 3);
+    if (lc("$f[0] $f[1]") eq lc("$channel $callsign")) {
+      $r = "DEL $r";
+      $found = 1;
+      last;
+    }
+  }
+
+  unless ($found) {
     print bold($callsign) . " is not registered in the POTA league for $channel\n";
     exit 0;
   }
 
-  flush_file(\@updated, $act);
+  flush_file($regs, $act);
   print "removed " . bold($callsign) . " from the POTA league in $channel\n";
   exit 0;
 }
@@ -251,7 +280,7 @@ my ($regs, $act) = parse_file();
 my @calls;
 my %reg_join;  # uc(call) => "YYYY-MM-DD" or undef for legacy entries
 if (defined $channel) {
-  for my $line (grep { lc((split(' ', $_, 3))[0]) eq lc($channel) } @{$regs}) {
+  for my $line (grep { !/^DEL\s/ && lc((split(' ', $_, 3))[0]) eq lc($channel) } @{$regs}) {
     my @f = split(' ', $line, 3);
     my $c = uc $f[1];
     push @calls, $c;
@@ -259,7 +288,7 @@ if (defined $channel) {
   }
 } else {
   my %seen;
-  for my $line (@{$regs}) {
+  for my $line (grep { !/^DEL\s/ } @{$regs}) {
     my @f = split(' ', $line, 3);
     my $c = uc $f[1];
     next if $seen{$c}++;

--- a/lib/potaleague
+++ b/lib/potaleague
@@ -5,15 +5,11 @@
 # Per-channel registrations persist in $HOME/.qrmbot/db/potaleague
 # (one entry per line: "<channel> <callsign>").
 # Activation and QSO counts are fetched live from the POTA API.
-# If $HOME/.qrmbot/creds/pota contains POTA_USER and POTA_PASS, the
-# authenticated API is used (full history); otherwise falls back to the
-# public profile API (last 25 activations only).
 #
 # 2-clause BSD license.
 # Copyright (c) 2026 nreed97@github. All rights reserved.
 
-# https://api.pota.app/activations/user/<callsign>  -- full history (auth req'd)
-# https://api.pota.app/profile/<callsign>           -- public, last 25 only
+# https://api.pota.app/profile/<callsign>  -- user profile / recent_activity
 
 use URI::Escape;
 use JSON qw( decode_json );
@@ -39,7 +35,6 @@ $exitnonzeroonerror = 0 if $username eq getEggdropUID();
 
 my $dbdir      = $ENV{'HOME'} . "/.qrmbot/db";
 my $leaguefile = "$dbdir/potaleague";
-my $credsfile  = $ENV{'HOME'} . "/.qrmbot/creds/pota";
 
 if (not -d $dbdir) {
   print "making db directory..\n";
@@ -158,22 +153,6 @@ if ($do_remove) {
   exit 0;
 }
 
-# ── Auth ──────────────────────────────────────────────────────────────────────
-# TOKEN in $credsfile is a POTA JWT, obtained from the browser:
-#   document.querySelector('#app').__vue__.$store.state.user.token
-# Paste the result into $HOME/.qrmbot/creds/pota as: TOKEN=eyJ...
-# Refresh it manually when it expires (~30 days).
-
-my $auth_token;
-if (-f $credsfile) {
-  open(my $cfh, '<', $credsfile) or die "cannot open $credsfile: $!";
-  while (<$cfh>) {
-    chomp;
-    if (/^TOKEN\s*=\s*(.+)$/) { $auth_token = $1; last; }
-  }
-  close($cfh);
-}
-
 # ── Leaderboard ───────────────────────────────────────────────────────────────
 
 my @entries = read_entries();
@@ -195,47 +174,31 @@ if (@calls == 0) {
 
 my %stats;
 for my $call (@calls) {
-  my $acts_ref;
+  my $url = "https://api.pota.app/profile/" . uri_escape($call);
 
-  if (defined $auth_token) {
-    my $url = "https://api.pota.app/activations/user/" . uri_escape($call);
-    local $/;
-    open(JSON, '-|', "curl -k -L --max-time 15 --retry 1 -s"
-                   . " -H 'Authorization: $auth_token' '$url'");
-    my $json = <JSON>;
-    close(JSON);
-    if (defined $json and $json ne "") {
-      my $j;
-      eval { $j = decode_json($json); };
-      $acts_ref = $j if !$@ and ref $j eq 'ARRAY';
-    }
-  }
+  local $/;
+  open(JSON, '-|', "curl -k -L --max-time 15 --retry 1 -s '$url'");
+  my $json = <JSON>;
+  close(JSON);
 
-  unless (defined $acts_ref) {
-    # fallback: public profile API, last 25 activations only
-    my $url = "https://api.pota.app/profile/" . uri_escape($call);
-    local $/;
-    open(JSON, '-|', "curl -k -L --max-time 15 --retry 1 -s '$url'");
-    my $json = <JSON>;
-    close(JSON);
-    next unless defined $json and $json ne "";
-    next if $json =~ /not found/i;
-    my $j;
-    eval { $j = decode_json($json); };
-    next if $@;
-    next unless ref $j eq 'HASH';
-    $acts_ref = $j->{recent_activity}{activations};
-  }
+  next unless defined $json and $json ne "";
+  next if $json =~ /not found/i;
 
-  next unless ref $acts_ref eq 'ARRAY';
+  my $j;
+  eval { $j = decode_json($json); };
+  next if $@;
+  next unless ref $j eq 'HASH';
+
+  my $acts = $j->{recent_activity}{activations};
+  next unless ref $acts eq 'ARRAY';
 
   my ($act_count, $qso_count) = (0, 0);
-  for my $act (@{$acts_ref}) {
+  for my $act (@{$acts}) {
     my $date     = $act->{date} // "";
     my $act_year = ($date =~ /^(\d{4})/) ? $1 : "";
     next unless $act_year eq $year;
     $act_count++;
-    $qso_count += $act->{totalQSOs} // $act->{total} // 0;
+    $qso_count += $act->{total} // 0;
   }
 
   $stats{$call} = { activations => $act_count, qsos => $qso_count }


### PR DESCRIPTION
## What changed

Revised caching strategy in response to maintainer feedback on the previous approach.

### Problem with the prior approach (TOTAL collapse)

The public POTA API (`/profile/<callsign>`) returns at most 25 most-recent activations across all time. There is no public endpoint that returns another user's full activation history — this was confirmed exhaustively (authenticated endpoints return 403 for arbitrary callsigns).

The prior approach collapsed past-year ACT lines into TOTAL lines. This produced **incorrect** data, not just incomplete data: a callsign active mostly in 2025 with their 25-record API window dominated by recent 2026 activity would show zero for 2025 — even if they were extremely active that year.

### New approach

**Current year only — accumulate ACT lines:**
- Each `!potaleague` run merges the latest API window into `ACT` lines, keyed by `callsign+date+park-ref`, deduplicated with `//=`.
- Only current-year activations are cached. Past-year API data is silently ignored.
- As long as `!potaleague` runs at least once within any member's 25-activation window, the current year count stays accurate.

**Historical year queries — live API, no cache:**
- `!potaleague 2025` queries the live API for each registered callsign and filters for that year's activations.
- Output is labeled `(approx)` to be honest about the 25-record limit.
- No `TOTAL` lines are written. Avoids locking in wrong data.

**New member problem — join date tracking:**
- When a callsign is registered with `!potaleagueadd`, today's date is stored in the registration line: `#channel CALL YYYY-MM-DD`.
- On the leaderboard, if a callsign was registered during the current year, their entry gets a `*` flag.
- A footnote prints: `* data tracked from join date; earlier activations not captured`
- This is honest: the count shown is a floor, not a ceiling, for new members.
- Legacy registration lines (no date) receive no asterisk — treated as always-tracked.

**Backward compatibility:**
- Existing `TOTAL` lines in the db file are silently discarded on first run (clean migration).
- Existing registration lines without a date continue to work unchanged.

### File format

```
#redditnet NV3Y 2026-01-01    ← registration with join date
#redditnet W0NY 2026-01-01
ACT NV3Y 2026 2026-04-01 US-4567 84   ← current year only
ACT NV3Y 2026 2026-04-10 US-1234 31
```

### Sample output

Current year with a new member:
```
POTA League 2026: 🥇 NV3Y (12A; 840Q) · 🥈 W0NY* (9A; 632Q) · 🥉 K2IW (5A; 58Q)
* data tracked from join date; earlier activations not captured
```

Historical year:
```
POTA League 2025 (approx): 🥇 K2IW (20A; 1,175Q) · 🥈 W0NY (9A; 632Q)
```