### PR TITLE
potaleague: reject year requests before 2026

### DIFF
--- a/lib/potaleague
+++ b/lib/potaleague
@@ -310,6 +310,10 @@ my @medals = ("\x{1F947}", "\x{1F948}", "\x{1F949}");
 # ── Historical year: live API only, no caching ────────────────────────────────
 
 if ($year ne $cur_year) {
+  if ($year < 2026) {
+    print "POTA League history is only available from 2026 onward.\n";
+    exit 0;
+  }
   my %stats;
   for my $call (@calls) {
     my $url = "https://api.pota.app/profile/" . uri_escape($call);


### PR DESCRIPTION
## Summary

- Adds a guard in `lib/potaleague` that rejects `!potaleague <year>` requests where the year is before 2026
- Returns a friendly IRC message: `POTA League history is only available from 2026 onward.`
- No API call is made and no data is written when the guard fires

## Why

The POTA API returns only the 25 most-recent activations across all time.  For years prior to 2026 the rolling window almost certainly no longer contains those activations, so any count returned would silently undercount (or show zero).  Wrong data is worse than no data, and the existing header comment already calls this out.  The fix simply surfaces that limitation to the user instead of letting the query proceed.

## Test plan

- [ ] `!potaleague 2025` → `POTA League history is only available from 2026 onward.`
- [ ] `!potaleague 2024` → same message
- [ ] `!potaleague 2026` → normal leaderboard (or approx results)
- [ ] `!potaleague` (no year) → current-year leaderboard unaffected
- [ ] `!potaleagueadd` / `!potaleaguedel` → unaffected (guard is inside the leaderboard path only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)