### PR TITLE
hamtrivia: add !hamtrivia FCC amateur radio exam trivia game

### DIFF
--- a/botcommands.md
+++ b/botcommands.md
@@ -91,6 +91,7 @@
  * `!translate` -- translate text
  * `!rand` `!dice` `!flip` `!8ball` `!orb` -- random
  * `!trivia` `!answer` -- IRC trivia game (Open Trivia Database, 3 rounds, 30 min cooldown)
+ * `!hamtrivia` `!answer` -- ham radio exam trivia game (Technician/General/Extra pools, 3 rounds, 30 min cooldown)
 
 ## Radio-related commands:
 
@@ -1123,6 +1124,43 @@ Example:
     ...
     < qrm> Final scores: 1. Crossbar: 2 | 2. molo: 1
     < qrm> Winner: Crossbar! Congratulations!
+```
+
+### `!hamtrivia` `!answer` -- ham radio exam trivia game
+
+Usage:
+```
+    !hamtrivia            start a ham radio trivia game in the channel
+    !answer <number>      submit your answer during a round
+    !hamtriviastop        abort the current game (molo/Crossbar only)
+```
+
+Starts a 3-round multiple-choice trivia game using FCC amateur radio exam
+questions drawn from the Technician, General, and Amateur Extra question pools.
+Questions that reference figures or diagrams are excluded since they cannot be
+displayed in IRC. Each question is labeled with its pool ID and license class
+(e.g. `[T1A01 Technician]`) for study reference.
+
+After `!hamtrivia`, there is a 30-second countdown before the first question.
+Each round shows a question with numbered options; players type `!answer <n>`
+(or `!a <n>`) to submit. Tie-break and scoring rules are the same as `!trivia`.
+
+Cooldown: 30 minutes per channel between games. molo and Crossbar are exempt.
+Question pools are downloaded from the
+[russolsen/ham_radio_question_pool](https://github.com/russolsen/ham_radio_question_pool)
+repository and cached locally for 30 days.
+
+Example:
+```
+    < W1AW> !hamtrivia
+    < qrm> 📡 Ham Radio Trivia starting in 30s! 3 rounds, 20s each. Type !a <number> to answer.
+    < qrm> 📡 Round 1/3 — [T1A01 Technician] Which of the following is a purpose of the Amateur Radio Service?
+    < qrm>   1) Advancing skills in technical and communication phases of the radio art  2) Providing communications for international non-profit organizations  3) Providing personal radio communications for as many citizens as possible  4) All of these choices are correct
+    < W1AW> !a 1
+    < qrm> Time! The correct answer was 1) Advancing skills...
+    ...
+    < qrm> 📊 Final scores: 1. W1AW: 2 | 2. KD9ABC: 1
+    < qrm> 🏆 Winner: W1AW! Elmer of the day! 73!
 ```
 
 <!-- !amcon - - some dumb prepper shit -->

--- a/lib/hamtrivia
+++ b/lib/hamtrivia
@@ -1,0 +1,165 @@
+#!/usr/bin/perl -w
+#
+# Select random FCC amateur radio exam questions from cached question pools.
+# Pools (Technician, General, Extra) are downloaded from the
+# russolsen/ham_radio_question_pool GitHub repository.
+# Questions that reference figures/diagrams are excluded.
+#
+# Output format (one line per question):
+#   correct_idx|[ID Class] question|opt1|opt2|opt3|opt4
+# where correct_idx is 1-based.
+#
+# Usage: hamtrivia --fetch [--count N]
+#
+# 2-clause BSD license.
+# Copyright (c) 2026 MonkeybutlerCJH. All rights reserved.
+
+use strict;
+use utf8;
+use feature 'unicode_strings';
+binmode(STDOUT, ":utf8");
+
+use JSON::PP qw(decode_json);
+use List::Util qw(shuffle);
+
+use File::Basename;
+use Cwd 'realpath';
+use lib dirname(realpath(__FILE__));
+use Util;
+
+my $username = $ENV{'USER'} || $ENV{'USERNAME'} || getpwuid($<);
+our $exitnonzeroonerror = 1;
+$exitnonzeroonerror = 0 if $username eq getEggdropUID();
+
+# eggdrop passes all args as one string
+@ARGV = split(' ', join(' ', @ARGV));
+
+my $useragent = "qrmbot hamtrivia/1.0";
+my $cache_dir = "$ENV{HOME}/.qrmbot/cache";
+my $cache_ttl = 30 * 86400;  # 30 days
+my $base_url  = "https://raw.githubusercontent.com/russolsen/ham_radio_question_pool/master";
+
+my %pool_urls = (
+    tech    => "$base_url/technician-2026-2030/technician-2026-2030.json",
+    general => "$base_url/general-2023-2027/general-2023-2027.json",
+    extra   => "$base_url/extra-2024-2028/extra-2024-2028.json",
+);
+
+my %pool_label = (
+    tech    => "Technician",
+    general => "General",
+    extra   => "Extra",
+);
+
+my $default_count = 10;
+my $count    = $default_count;
+my $do_fetch = 0;
+
+while (@ARGV) {
+    my $arg = shift @ARGV;
+    if ($arg eq "--fetch") {
+        $do_fetch = 1;
+    } elsif ($arg eq "--count") {
+        $count = shift @ARGV;
+    }
+}
+
+unless ($do_fetch) {
+    print STDERR "Usage: hamtrivia --fetch [--count N]\n";
+    exit($exitnonzeroonerror ? 1 : 0);
+}
+
+fetch_questions($count);
+
+sub load_pool {
+    my ($class) = @_;
+    my $cache_file = "$cache_dir/hamtrivia_${class}.json";
+
+    # Use cache if fresh enough
+    if (-f $cache_file && (time() - (stat($cache_file))[9]) < $cache_ttl) {
+        local $/;
+        open(my $fh, '<:utf8', $cache_file) or return ();
+        my $json = <$fh>;
+        close $fh;
+        my $data = eval { decode_json($json) };
+        return @$data if !$@ && ref($data) eq 'ARRAY';
+    }
+
+    # Download fresh copy
+    my $json = curl_get($pool_urls{$class});
+
+    if (defined $json) {
+        my $data = eval { decode_json($json) };
+        if (!$@ && ref($data) eq 'ARRAY') {
+            mkdir $cache_dir unless -d $cache_dir;
+            if (open(my $fh, '>:utf8', $cache_file)) {
+                print $fh $json;
+                close $fh;
+            }
+            return @$data;
+        }
+    }
+
+    # Fall back to stale cache rather than fail silently
+    if (-f $cache_file) {
+        local $/;
+        open(my $fh, '<:utf8', $cache_file) or return ();
+        my $json = <$fh>;
+        close $fh;
+        my $data = eval { decode_json($json) };
+        return @$data if !$@ && ref($data) eq 'ARRAY';
+    }
+
+    return ();
+}
+
+sub fetch_questions {
+    my ($n) = @_;
+
+    my @all;
+    for my $class (sort keys %pool_urls) {
+        for my $q (load_pool($class)) {
+            # Skip questions that require a figure/diagram
+            next if defined $q->{figure} && $q->{figure} ne '';
+            next if $q->{question} =~ /figure/i;
+            next if grep { /figure/i } @{$q->{answers} // []};
+
+            push @all, { %$q, _class => $class };
+        }
+    }
+
+    unless (@all) {
+        print STDERR "hamtrivia: no questions available\n";
+        exit($exitnonzeroonerror ? 1 : 0);
+    }
+
+    my @shuffled = shuffle(@all);
+    my $take = ($n <= scalar(@shuffled)) ? $n : scalar(@shuffled);
+    my @selected = @shuffled[0 .. $take - 1];
+
+    for my $q (@selected) {
+        my $id      = $q->{id} // '?';
+        my $class   = $pool_label{$q->{_class}} // $q->{_class};
+        my $correct = $q->{correct};         # 0-based integer from pool data
+        my $question = $q->{question};
+        my @answers  = @{$q->{answers}};
+
+        # Sanitize pipe characters used as field delimiter
+        $question =~ s/\|/\//g;
+        @answers  = map { s/\|/\//gr } @answers;
+        $id       =~ s/\|/\//g;
+
+        # Prefix question with ID and license class for educational context
+        my $full_question = "[$id $class] $question";
+
+        # Output: 1-based correct index, question, then 4 answer choices
+        print join("|", $correct + 1, $full_question, @answers), "\n";
+    }
+}
+
+sub curl_get {
+    my ($url) = @_;
+    my $out = `curl --max-time 30 -s -k -L -A "$useragent" '$url'`;
+    return undef if $? != 0 || !defined $out || $out eq '';
+    return $out;
+}

--- a/scripts/fun.tcl
+++ b/scripts/fun.tcl
@@ -1924,6 +1924,359 @@ bind pub - !a          trivia_answer_pub
 bind pub - !triviastop trivia_stop_pub
 
 
+# ============================================================================
+# !hamtrivia — Multi-round IRC trivia game using FCC amateur radio exam questions
+#
+# Commands:
+#   !hamtrivia      — start a game (30-second countdown, then 3 rounds of 20s)
+#   !answer <n>, !a <n> — submit answer during a round
+#   !hamtriviastop  — abort a game (molo/Crossbar only)
+#
+# Cooldown: 30 minutes per channel. molo and Crossbar are exempt.
+# Tie-break: keep asking questions; players who answer wrong are eliminated
+#            until one player remains.
+# Questions sourced from Technician, General, and Extra pools; figure questions
+# are excluded since diagrams cannot be shown in IRC.
+# ============================================================================
+
+set hamtriviabin            "/home/eggdrop/bin/hamtrivia"
+set hamtrivia_rounds        3
+set hamtrivia_round_secs    20
+set hamtrivia_start_delay   30
+set hamtrivia_cooldown_secs 1800
+
+array set hamtrivia_active        {}
+array set hamtrivia_starting      {}
+array set hamtrivia_questions     {}
+array set hamtrivia_qindex        {}
+array set hamtrivia_round         {}
+array set hamtrivia_scores        {}
+array set hamtrivia_answered      {}
+array set hamtrivia_correct       {}
+array set hamtrivia_round_correct {}
+array set hamtrivia_tiebreak      {}
+array set hamtrivia_tienicks      {}
+array set hamtrivia_tb_noanswer   {}
+array set hamtrivia_last_game     {}
+
+proc hamtrivia_clear {chan} {
+    global hamtrivia_active hamtrivia_starting hamtrivia_questions hamtrivia_qindex
+    global hamtrivia_round hamtrivia_scores hamtrivia_answered hamtrivia_correct
+    global hamtrivia_tiebreak hamtrivia_tienicks hamtrivia_round_correct hamtrivia_tb_noanswer
+    set hamtrivia_active($chan)        0
+    set hamtrivia_starting($chan)      0
+    set hamtrivia_questions($chan)     {}
+    set hamtrivia_qindex($chan)        0
+    set hamtrivia_round($chan)         0
+    set hamtrivia_scores($chan)        {}
+    set hamtrivia_answered($chan)      {}
+    set hamtrivia_correct($chan)       0
+    set hamtrivia_tiebreak($chan)      0
+    set hamtrivia_tienicks($chan)      {}
+    set hamtrivia_round_correct($chan) {}
+    set hamtrivia_tb_noanswer($chan)   0
+}
+
+proc hamtrivia_pub {nick host hand chan text} {
+    global hamtrivia_active hamtrivia_starting hamtrivia_last_game
+    global hamtrivia_cooldown_secs hamtrivia_rounds hamtrivia_round_secs hamtrivia_start_delay
+    global trivia_active trivia_starting
+
+    if {[info exists trivia_active($chan)] && $trivia_active($chan)} {
+        putchan $chan "⚠️ A trivia game is already in progress. Use !a <number> to play!"
+        return
+    }
+    if {[info exists trivia_starting($chan)] && $trivia_starting($chan)} {
+        putchan $chan "⚠️ A trivia game is starting soon. Get ready!"
+        return
+    }
+    if {[info exists hamtrivia_active($chan)] && $hamtrivia_active($chan)} {
+        putchan $chan "⚠️ A Ham Radio Trivia game is already in progress. Use !a <number> to play!"
+        return
+    }
+    if {[info exists hamtrivia_starting($chan)] && $hamtrivia_starting($chan)} {
+        putchan $chan "⚠️ A Ham Radio Trivia game is starting soon. Get ready!"
+        return
+    }
+
+    if {![trivia_is_exempt $nick]} {
+        if {[info exists hamtrivia_last_game($chan)]} {
+            set elapsed [expr {[clock seconds] - $hamtrivia_last_game($chan)}]
+            if {$elapsed < $hamtrivia_cooldown_secs} {
+                set remaining [expr {$hamtrivia_cooldown_secs - $elapsed}]
+                set nexttime [clock format [expr {[clock seconds] + $remaining}] -format "%H:%M UTC" -gmt 1]
+                putchan $chan "⏳ $nick: Ham Radio Trivia is on cooldown. Next game allowed at $nexttime."
+                return
+            }
+        }
+    }
+
+    hamtrivia_clear $chan
+    set hamtrivia_starting($chan) 1
+    putchan $chan "📡 Ham Radio Trivia starting in ${hamtrivia_start_delay}s! $hamtrivia_rounds rounds, ${hamtrivia_round_secs}s each. Type !a <number> to answer."
+    utimer $hamtrivia_start_delay [list hamtrivia_start $chan]
+}
+
+proc hamtrivia_start {chan} {
+    global hamtriviabin hamtrivia_starting hamtrivia_active hamtrivia_questions
+    global hamtrivia_qindex hamtrivia_round hamtrivia_last_game
+
+    if {![info exists hamtrivia_starting($chan)] || !$hamtrivia_starting($chan)} { return }
+    set hamtrivia_starting($chan) 0
+
+    set lines {}
+    if {[catch {
+        set fd [open "|${hamtriviabin} --fetch --count 10" r]
+        fconfigure $fd -encoding utf-8
+        while {[gets $fd line] >= 0} {
+            if {$line ne ""} { lappend lines $line }
+        }
+        close $fd
+    } err]} {
+        putchan $chan "❌ Ham Radio Trivia error: could not fetch questions. Try again later."
+        putlog "hamtrivia_start error: $err"
+        return
+    }
+
+    if {[llength $lines] == 0} {
+        putchan $chan "❌ Ham Radio Trivia error: no questions returned. Try again later."
+        return
+    }
+
+    set hamtrivia_active($chan)    1
+    set hamtrivia_questions($chan) $lines
+    set hamtrivia_qindex($chan)    0
+    set hamtrivia_round($chan)     1
+    set hamtrivia_last_game($chan) [clock seconds]
+
+    hamtrivia_ask $chan
+}
+
+proc hamtrivia_ask {chan} {
+    global hamtrivia_questions hamtrivia_qindex hamtrivia_correct hamtrivia_answered hamtrivia_round_correct
+    global hamtrivia_round hamtrivia_rounds hamtrivia_round_secs hamtrivia_tiebreak hamtrivia_tienicks
+
+    set qlist $hamtrivia_questions($chan)
+    set idx   $hamtrivia_qindex($chan)
+
+    if {$idx >= [llength $qlist]} {
+        putchan $chan "❌ Ham Radio Trivia: ran out of questions. Game over!"
+        hamtrivia_end_game $chan
+        return
+    }
+
+    set line [lindex $qlist $idx]
+    incr hamtrivia_qindex($chan)
+
+    set parts    [split $line "|"]
+    set correct  [lindex $parts 0]
+    set question [lindex $parts 1]
+    set options  [lrange $parts 2 end]
+
+    set hamtrivia_correct($chan)       $correct
+    set hamtrivia_answered($chan)      {}
+    set hamtrivia_round_correct($chan) {}
+
+    if {$hamtrivia_tiebreak($chan)} {
+        set label "⚡ Tiebreaker (still in: [join $hamtrivia_tienicks($chan) {, }])"
+    } else {
+        set label "📡 Round $hamtrivia_round($chan)/$hamtrivia_rounds"
+    }
+
+    putchan $chan "\002$label\002 — $question"
+
+    set i 1
+    set optline ""
+    foreach opt $options {
+        append optline "  \002${i})\002 $opt"
+        incr i
+    }
+    putchan $chan $optline
+
+    utimer $hamtrivia_round_secs [list hamtrivia_round_end $chan]
+}
+
+proc hamtrivia_answer_pub {nick host hand chan text} {
+    global hamtrivia_active hamtrivia_tiebreak hamtrivia_tienicks
+    global hamtrivia_answered hamtrivia_correct hamtrivia_scores hamtrivia_questions hamtrivia_round_correct hamtrivia_qindex
+
+    if {![info exists hamtrivia_active($chan)] || !$hamtrivia_active($chan)} { return }
+
+    if {$hamtrivia_tiebreak($chan)} {
+        if {[lsearch -exact $hamtrivia_tienicks($chan) $nick] == -1} { return }
+    }
+
+    if {[lsearch -exact $hamtrivia_answered($chan) $nick] != -1} {
+        putchan $chan "$nick: you already answered this round!"
+        return
+    }
+
+    set ans [string trim $text]
+    if {![string is integer -strict $ans] || $ans < 1} {
+        putchan $chan "$nick: please answer with a number (e.g. !a 2)"
+        return
+    }
+
+    set parts [split [lindex $hamtrivia_questions($chan) [expr {$hamtrivia_qindex($chan) - 1}]] "|"]
+    set nopts [expr {[llength $parts] - 2}]
+    if {$ans > $nopts} {
+        putchan $chan "$nick: answer must be between 1 and $nopts"
+        return
+    }
+
+    lappend hamtrivia_answered($chan) $nick
+
+    if {$ans == $hamtrivia_correct($chan)} {
+        if {![dict exists $hamtrivia_scores($chan) $nick]} {
+            set hamtrivia_scores($chan) [dict set hamtrivia_scores($chan) $nick 0]
+        }
+        dict incr hamtrivia_scores($chan) $nick
+        lappend hamtrivia_round_correct($chan) $nick
+    }
+}
+
+proc hamtrivia_round_end {chan} {
+    global hamtrivia_correct hamtrivia_questions hamtrivia_qindex hamtrivia_round hamtrivia_rounds
+    global hamtrivia_tiebreak hamtrivia_answered hamtrivia_scores hamtrivia_active
+
+    if {![info exists hamtrivia_active($chan)] || !$hamtrivia_active($chan)} { return }
+
+    set parts   [split [lindex $hamtrivia_questions($chan) [expr {$hamtrivia_qindex($chan) - 1}]] "|"]
+    set correct $hamtrivia_correct($chan)
+    set answer  [lindex $parts [expr {$correct + 1}]]
+
+    putchan $chan "⏰ Time! The correct answer was \002${correct}) ${answer}\002."
+
+    if {$hamtrivia_tiebreak($chan)} {
+        hamtrivia_tiebreaker_eval $chan
+        return
+    }
+
+    incr hamtrivia_round($chan)
+    if {$hamtrivia_round($chan) <= $hamtrivia_rounds} {
+        utimer 3 [list hamtrivia_ask $chan]
+    } else {
+        hamtrivia_end_game $chan
+    }
+}
+
+proc hamtrivia_end_game {chan} {
+    global hamtrivia_scores
+
+    set scores $hamtrivia_scores($chan)
+
+    if {[dict size $scores] == 0} {
+        putchan $chan "Game over! No one scored. Study that question pool and try again!"
+        hamtrivia_clear $chan
+        return
+    }
+
+    set pairs {}
+    dict for {nick score} $scores { lappend pairs [list $nick $score] }
+    set pairs [lsort -integer -decreasing -index 1 $pairs]
+
+    set board ""
+    set place 1
+    foreach p $pairs {
+        set n [lindex $p 0]
+        set s [lindex $p 1]
+        append board " | ${place}. $n: $s"
+        incr place
+    }
+    putchan $chan "📊 Final scores: [string range $board 3 end]"
+
+    set maxscore [lindex [lindex $pairs 0] 1]
+    set winners {}
+    foreach p $pairs {
+        if {[lindex $p 1] == $maxscore} { lappend winners [lindex $p 0] }
+    }
+
+    if {[llength $winners] == 1} {
+        putchan $chan "🏆 Winner: \002[lindex $winners 0]\002! Elmer of the day! 73!"
+        hamtrivia_clear $chan
+    } else {
+        putchan $chan "🤝 It's a tie between: \002[join $winners {, }]\002! Starting tiebreaker..."
+        global hamtrivia_tiebreak hamtrivia_tienicks
+        set hamtrivia_tiebreak($chan) 1
+        set hamtrivia_tienicks($chan) $winners
+        utimer 3 [list hamtrivia_ask $chan]
+    }
+}
+
+proc hamtrivia_tiebreaker_eval {chan} {
+    global hamtrivia_tienicks hamtrivia_round_correct hamtrivia_tb_noanswer hamtrivia_answered
+
+    set correct_nicks $hamtrivia_round_correct($chan)
+
+    set eliminated {}
+    foreach nick $hamtrivia_tienicks($chan) {
+        if {[lsearch -exact $correct_nicks $nick] == -1} {
+            lappend eliminated $nick
+        }
+    }
+
+    if {[llength $eliminated] == 0 || [llength $eliminated] == [llength $hamtrivia_tienicks($chan)]} {
+        if {[llength $correct_nicks] == 0} {
+            if {[llength $hamtrivia_answered($chan)] == 0} {
+                incr hamtrivia_tb_noanswer($chan)
+                if {$hamtrivia_tb_noanswer($chan) >= 2} {
+                    putchan $chan "🤝 Nobody answered for 2 rounds. It's a draw between: \002[join $hamtrivia_tienicks($chan) {, }]\002!"
+                    hamtrivia_clear $chan
+                    return
+                }
+                putchan $chan "😴 Nobody answered — no change! Another tiebreaker..."
+            } else {
+                putchan $chan "💀 Nobody answered correctly — no change! Another tiebreaker..."
+            }
+        } else {
+            set hamtrivia_tb_noanswer($chan) 0
+            putchan $chan "🎯 Everyone answered correctly — no change! Another tiebreaker..."
+        }
+        utimer 3 [list hamtrivia_ask $chan]
+        return
+    }
+
+    set hamtrivia_tb_noanswer($chan) 0
+
+    foreach nick $eliminated {
+        set idx [lsearch -exact $hamtrivia_tienicks($chan) $nick]
+        if {$idx != -1} {
+            set hamtrivia_tienicks($chan) [lreplace $hamtrivia_tienicks($chan) $idx $idx]
+        }
+    }
+
+    putchan $chan "❌ Eliminated: [join $eliminated {, }]."
+
+    if {[llength $hamtrivia_tienicks($chan)] == 1} {
+        putchan $chan "🏆 Winner: \002[lindex $hamtrivia_tienicks($chan) 0]\002! Elmer of the day! 73!"
+        hamtrivia_clear $chan
+    } else {
+        putchan $chan "🤝 Still tied: \002[join $hamtrivia_tienicks($chan) {, }]\002. Another tiebreaker..."
+        utimer 3 [list hamtrivia_ask $chan]
+    }
+}
+
+proc hamtrivia_stop_pub {nick host hand chan text} {
+    global hamtrivia_active hamtrivia_starting
+    if {![trivia_is_exempt $nick]} {
+        putchan $chan "🚫 $nick: only molo or Crossbar can stop a Ham Radio Trivia game."
+        return
+    }
+    if {([info exists hamtrivia_active($chan)] && $hamtrivia_active($chan)) ||
+        ([info exists hamtrivia_starting($chan)] && $hamtrivia_starting($chan))} {
+        hamtrivia_clear $chan
+        putchan $chan "🛑 Ham Radio Trivia stopped by $nick."
+    } else {
+        putchan $chan "No Ham Radio Trivia game is running."
+    }
+}
+
+bind pub - !hamtrivia     hamtrivia_pub
+bind pub - !a             hamtrivia_answer_pub
+bind pub - !answer        hamtrivia_answer_pub
+bind pub - !hamtriviastop hamtrivia_stop_pub
+
+
 # NHL scores: !nhl <team> plus common aliases
 set nhlbin "/home/eggdrop/bin/nhl"
 bind pub - !nhl nhl_pub


### PR DESCRIPTION
## Summary

- Adds `!hamtrivia` — a new multi-round IRC trivia game that draws questions from the three FCC amateur radio exam question pools (Technician, General, Amateur Extra)
- Questions referencing figures or diagrams are filtered out (can't be shown in IRC); the rest are displayed with their pool ID and license class prefix (e.g. `[T1A01 Technician]`) for study reference
- Follows the exact same engine conventions as `!trivia` (3 rounds × 20s, 30s start delay, 30-min cooldown, tiebreaker elimination, `!a`/`!answer` shared commands)

## Files changed

- **`lib/hamtrivia`** — Perl script that fetches the three exam pools from [`russolsen/ham_radio_question_pool`](https://github.com/russolsen/ham_radio_question_pool) on GitHub Raw, caches them locally for 30 days, and outputs N random questions in the same pipe-delimited format as `lib/trivia` (`correct_idx|question|opt1|opt2|opt3|opt4`)
- **`scripts/fun.tcl`** — `hamtrivia_*` game engine (≈250 lines) modeled directly on the `trivia_*` engine; `!a`/`!answer` are bound to both answer handlers — each guards on its own `_active` flag so the two games coexist safely; `!hamtrivia` also refuses to start if a regular trivia game is already running
- **`botcommands.md`** — documents `!hamtrivia`, `!hamtriviastop`, and `!answer`

## Test plan

- [ ] `hamtrivia --fetch --count 5` produces 5 well-formed pipe-delimited lines with no figure questions
- [ ] `!hamtrivia` in channel triggers 30s countdown then 3 questions from the ham pool, each prefixed `[T1A01 Technician]` / `[G…]` / `[E…]`
- [ ] `!a <n>` scores correctly; wrong answers do not
- [ ] Starting `!hamtrivia` while `!trivia` is active prints the "already in progress" warning
- [ ] `!triviastop` and `!hamtriviastop` each only stop their own game
- [ ] Cache files appear in `~/.qrmbot/cache/hamtrivia_{tech,general,extra}.json` after first fetch
- [ ] 30-min cooldown enforced; molo/Crossbar are exempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)