### PR TITLE
mlb: force Eastern timezone for schedule date

### DIFF
--- a/lib/mlb
+++ b/lib/mlb
@@ -28,6 +28,10 @@ $exitnonzeroonerror = 0 if $username eq getEggdropUID();
 @ARGV = split(' ', join(' ', @ARGV));
 
 my $useragent = "Mozilla/5.0 (compatible; qrmbot)";
+
+# MLB schedules use Eastern Time dates — force TZ so !mlb works correctly
+# when the server clock is UTC (otherwise after 8pm ET it rolls to tomorrow)
+$ENV{TZ} = 'America/New_York';
 my $today = strftime("%Y-%m-%d", localtime);
 my $year  = strftime("%Y", localtime);
 


### PR DESCRIPTION
## Summary

The eggdrop server runs on UTC, so after 8pm ET `localtime` rolls to the next day and the MLB schedule API returns all preview games (no scores, no innings). This forces `TZ=America/New_York` so `!mlb` always queries the correct Eastern Time date.

## Test plan

- [x] `TZ=UTC perl lib/mlb` — shows live scores instead of all preview games
- [x] `TZ=UTC perl lib/mlb yankees` — shows live game details with count/play-by-play
- [x] Regular local usage unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)