### PR TITLE
fix: prevent infinite tiebreaker loop when trivia runs out of questions

### DIFF
--- a/scripts/trivia.tcl
+++ b/scripts/trivia.tcl
@@ -284,6 +284,9 @@ proc trivia_end_game {chan} {
     if {[llength $winners] == 1} {
         putchan $chan "🏆 Winner: \002[lindex $winners 0]\002! Congratulations!"
         trivia_clear $chan
+    } elseif {$trivia_qindex($chan) >= [llength $trivia_questions($chan)]} {
+        putchan $chan "🤝 Not enough questions for a tiebreaker. It's a draw between: \002[join $winners {, }]\002!"
+        trivia_clear $chan
     } else {
         putchan $chan "🤝 It's a tie between: \002[join $winners {, }]\002! Starting tiebreaker..."
         global trivia_tiebreak trivia_tienicks
@@ -647,6 +650,9 @@ proc hamtrivia_end_game {chan} {
 
     if {[llength $winners] == 1} {
         putchan $chan "🏆 Winner: \002[lindex $winners 0]\002! Elmer of the day! 73!"
+        hamtrivia_clear $chan
+    } elseif {$hamtrivia_qindex($chan) >= [llength $hamtrivia_questions($chan)]} {
+        putchan $chan "🤝 Not enough questions for a tiebreaker. It's a draw between: \002[join $winners {, }]\002!"
         hamtrivia_clear $chan
     } else {
         putchan $chan "🤝 It's a tie between: \002[join $winners {, }]\002! Starting tiebreaker..."


### PR DESCRIPTION
## Summary
- When a tie occurs and the question pool is exhausted, `trivia_end_game` / `hamtrivia_end_game` would schedule another `_ask`, which immediately hit "ran out of questions" and called `_end_game` again — looping forever
- Added a guard in both `_end_game` procs: if no questions remain, declare the tie as a draw instead of starting a tiebreaker

## Test plan
- [ ] Trigger a tie in !trivia after exhausting all questions → should exit cleanly with "Not enough questions for a tiebreaker"
- [ ] Trigger a tie in !hamtrivia after exhausting all questions → same
- [ ] Normal tiebreaker with questions remaining still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)