### PR TITLE
fix: add missing global declarations in trivia/hamtrivia end_game

### DIFF
--- a/scripts/trivia.tcl
+++ b/scripts/trivia.tcl
@@ -251,7 +251,7 @@ proc trivia_round_end {chan} {
 }
 
 proc trivia_end_game {chan} {
-    global trivia_scores
+    global trivia_scores trivia_qindex trivia_questions
 
     set scores $trivia_scores($chan)
 
@@ -618,7 +618,7 @@ proc hamtrivia_round_end {chan} {
 }
 
 proc hamtrivia_end_game {chan} {
-    global hamtrivia_scores
+    global hamtrivia_scores hamtrivia_qindex hamtrivia_questions
 
     set scores $hamtrivia_scores($chan)
 


### PR DESCRIPTION
## Summary

Commit cae03dc added an `elseif` guard to prevent infinite tiebreaker loops when questions run out, but the condition references `trivia_qindex` and `trivia_questions` (and their `hamtrivia_*` equivalents) — arrays that weren't declared as `global` in the `end_game` procs.

In TCL, accessing an undeclared array element throws a runtime error that silently aborts the proc. This caused both `!trivia` and `!hamtrivia` to print "Final scores" and then crash before starting the tiebreaker or cleaning up — leaving `trivia_active` stuck at 1 permanently, blocking all future games.

**Fix:** Add the two missing array names to each proc's `global` declaration.

## Before/After

```
-    global trivia_scores
+    global trivia_scores trivia_qindex trivia_questions

-    global hamtrivia_scores
+    global hamtrivia_scores hamtrivia_qindex hamtrivia_questions
```

## Test plan

- [x] 3-way tie with questions remaining → tiebreaker starts (previously crashed)
- [x] Single winner → announces winner, clears game (no change)
- [x] Tie with exhausted questions → draw, clears game (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)