### PR TITLE
mlb: add wildcard standing to team display

### DIFF
--- a/lib/mlb
+++ b/lib/mlb
@@ -526,6 +526,23 @@ sub getStandingsLine {
           } else {
             my $ord = $divRank . ($divRank eq '2' ? 'nd' : $divRank eq '3' ? 'rd' : 'th');
             $line .= $sep . "$ord in $divName" . ($gb && $gb ne '-' ? " ($gb GB)" : "");
+
+            # Wildcard standing
+            my $wcRank = $trec->{wildCardRank} // '';
+            my $wcGB   = $trec->{wildCardGamesBack} // '';
+            if ($wcRank && $wcGB ne '') {
+              if ($wcGB eq '-' || $wcGB =~ /^\+/) {
+                # In a wildcard spot
+                my $wcStr = "WC$wcRank";
+                if ($wcGB =~ /^\+(\d+\.?\d*)/) {
+                  $wcStr .= " (+$1 GA)";
+                }
+                $line .= $sep . green($wcStr);
+              } else {
+                # Outside looking in
+                $line .= $sep . "$wcGB GB of WC";
+              }
+            }
           }
         }
         return $line;


### PR DESCRIPTION
## Summary
- Team commands (`!mlb yankees`, `!phillies`, etc.) now show wildcard standing when the team isn't leading their division
- Teams in a wildcard spot show `WC# (+X.X GA)` with their cushion above the cutoff
- Teams outside the wildcard show `X.X GB of WC` — how far back they are

## Examples
| Scenario | Output |
|---|---|
| In WC spot with cushion | `Yankees (26-16) · 2nd in AL East (2.0 GB) · WC1 (+6.0 GA)` |
| In WC spot, tied | `White Sox (19-21) · 2nd in AL Central (1.5 GB) · WC3` |
| Outside WC, chasing | `Orioles (19-23) · 3rd in AL East (9.0 GB) · 1.0 GB of WC` |
| Division leader | `Rays (27-13) · 1st in AL East` (no WC info) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)