### PR TITLE
amtrak: suggest nearby trains when requested train not found

### DIFF
--- a/lib/amtrak
+++ b/lib/amtrak
@@ -85,9 +85,11 @@ my $j = decode_json($json);
 
 $i = 0;
 my $found = 0;
+my @all_trains;
 
 while (defined $j->[$i]) {
   my $number = $j->[$i]->{number};
+  push @all_trains, $j->[$i] if defined $number;
   if (defined $number and $number == $trainId) {
     $found = 1;
     my $rec = $j->[$i];
@@ -136,8 +138,17 @@ while (defined $j->[$i]) {
   $i++;
 }
 
-print "$trainId not found\n" if not $found;
-exit $exitnonzeroonerror if not $found;
+if (not $found) {
+  my @sorted = sort { abs($a->{number} - $trainId) <=> abs($b->{number} - $trainId) } @all_trains;
+  my @suggestions = grep { defined $_ } @sorted[0..2];
+  print "Train $trainId not found";
+  if (@suggestions) {
+    my @desc = map { "#$_->{number} ($_->{origin} -> $_->{destination})" } @suggestions;
+    print " -- nearby trains: ", join(", ", @desc);
+  }
+  print "\n";
+  exit $exitnonzeroonerror;
+}
 
 
 sub updateAmtrakStations {


### PR DESCRIPTION
## Summary

- When a train number is not found in the live Amtrak data, the command now suggests up to 3 numerically nearby trains that are currently active.
- Output example: `Train 99 not found -- nearby trains: #97 (New York -> Chicago), #98 (Chicago -> New York), #101 (Los Angeles -> Seattle)`
- Since Amtrak paired long-distance routes use consecutive odd/even numbers (e.g., California Zephyr 5/6, Empire Builder 7/8), the closest suggestions will usually include the partner train on the same corridor.

## What changed

- Collect all trains into `@all_trains` while iterating the API response.
- On not-found, sort by numeric distance from the requested train number and display the 3 closest with their origin/destination.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)