### PR TITLE
polymarket: filter out negRiskOther markets from event output

### DIFF
--- a/lib/polymarket
+++ b/lib/polymarket
@@ -170,7 +170,7 @@ sub longest_common_suffix {
 sub print_event {
   my ($event, $event_url) = @_;
   my $title   = $event->{title} // "Unknown";
-  my @markets = grep { !$_->{archived} } @{$event->{markets} // []};
+  my @markets = grep { !$_->{archived} && !$_->{negRiskOther} } @{$event->{markets} // []};
   my $sep     = " \x{00B7} ";
 
   if (@markets == 0) {


### PR DESCRIPTION
These are synthetic markets that exist for Polymarket's internal neg-risk market structure. The Polymarket website hides them, but our code was displaying them.

Example: the "which continent will win the World Cup" event was showing "another continent 0%" — a negRiskOther market with `outcomePrices: null` that doesn't appear on the actual Polymarket page.

Fix: filter `negRiskOther` markets in `print_event()`, matching the Polymarket frontend behavior.