### PR TITLE
worldcup: show knockout round label instead of group in knockout stage

### DIFF
--- a/lib/worldcup
+++ b/lib/worldcup
@@ -770,12 +770,12 @@ if (defined $teamEvent) {
     }
   }
 
-  # Build round prefix
+  # Build round prefix — prefer next event's season since that's the upcoming match
   my $season = '';
-  if (defined $lastEvent) {
-    $season = $lastEvent->{season}{slug} // '';
-  } elsif (defined $nextEvent) {
+  if (defined $nextEvent) {
     $season = $nextEvent->{season}{slug} // '';
+  } elsif (defined $lastEvent) {
+    $season = $lastEvent->{season}{slug} // '';
   }
   my $round = $roundLabel{$season} // $season;
   my $prefix = '';

--- a/lib/worldcup
+++ b/lib/worldcup
@@ -770,24 +770,19 @@ if (defined $teamEvent) {
     }
   }
 
-  # Build round prefix — prefer next event's season since that's the upcoming match
-  my $season = '';
-  if (defined $nextEvent) {
-    $season = $nextEvent->{season}{slug} // '';
-  } elsif (defined $lastEvent) {
-    $season = $lastEvent->{season}{slug} // '';
-  }
-  my $round = $roundLabel{$season} // $season;
-  my $prefix = '';
-  if (defined $group && $season eq 'group-stage') {
-    $prefix = grey("[" . $group->{name} . "] ");
-  } else {
-    $prefix = grey("[$round] ");
-  }
-
   my @parts;
 
   if (defined $lastEvent) {
+    # Prefix based on last event's own round
+    my $lSeason = $lastEvent->{season}{slug} // '';
+    my $lPrefix = '';
+    if ($lSeason eq 'group-stage' && defined $group) {
+      $lPrefix = grey("[" . $group->{name} . "] ");
+    } elsif ($lSeason) {
+      my $lRound = $roundLabel{$lSeason} // $lSeason;
+      $lPrefix = grey("[$lRound] ");
+    }
+
     my ($lHome, $lAway) = getCompetitors($lastEvent);
     next unless defined($lHome) && defined($lAway);
     my $lA = $lAway->{team}{abbreviation} // '???';
@@ -795,10 +790,20 @@ if (defined $teamEvent) {
     my $lAS = $lAway->{score} // 0;
     my $lHS = $lHome->{score} // 0;
     my $lDate = fmtDate($lastDate // '');
-    push @parts, "Last ($lDate): " . bold($lA) . " $lAS-$lHS " . bold($lH);
+    push @parts, $lPrefix . "Last ($lDate): " . bold($lA) . " $lAS-$lHS " . bold($lH);
   }
 
   if (defined $nextEvent) {
+    # Prefix based on next event's own round
+    my $nSeason = $nextEvent->{season}{slug} // '';
+    my $nPrefix = '';
+    if ($nSeason eq 'group-stage' && defined $group) {
+      $nPrefix = grey("[" . $group->{name} . "] ");
+    } elsif ($nSeason) {
+      my $nRound = $roundLabel{$nSeason} // $nSeason;
+      $nPrefix = grey("[$nRound] ");
+    }
+
     my ($nHome, $nAway) = getCompetitors($nextEvent);
     if (defined($nHome) && defined($nAway)) {
       my $nA = $nAway->{team}{abbreviation} // '???';
@@ -807,7 +812,7 @@ if (defined $teamEvent) {
       my $nHName = $nHome->{team}{name} // $nH;
       my $nDate = fmtDate($nextDate // '');
       my $nTime = fmtTime($nextEvent->{date});
-      my $nextStr = "Next ($nDate): " . bold($nAName) . " vs " . bold($nHName)
+      my $nextStr = $nPrefix . "Next ($nDate): " . bold($nAName) . " vs " . bold($nHName)
                   . ($nTime ? "  $nTime" : '');
       my $odds = fetchPolymarketOdds($nAName, $nHName, $nA, $nH);
       $nextStr .= "  $odds" if defined $odds;
@@ -816,7 +821,7 @@ if (defined $teamEvent) {
   }
 
   if (@parts) {
-    my $msg = $prefix . join($bar, @parts);
+    my $msg = join($bar, @parts);
 
     print "$msg\n";
   } else {

--- a/lib/worldcup
+++ b/lib/worldcup
@@ -316,10 +316,9 @@ sub renderTeamGame {
   my $bar = $isIRC ? " \x{00B7} " : "\n";
   my $msg;
 
-  # Round / group prefix
+  # Round / group prefix — only show group in group stage, otherwise show round
   my $prefix = '';
-  if (defined $group) {
-    # Use the group name directly (e.g. "[Group D]") instead of round + group
+  if (defined $group && $season eq 'group-stage') {
     $prefix = grey("[" . $group->{name} . "] ");
   } else {
     $prefix = grey("[$round] ");
@@ -780,7 +779,7 @@ if (defined $teamEvent) {
   }
   my $round = $roundLabel{$season} // $season;
   my $prefix = '';
-  if (defined $group) {
+  if (defined $group && $season eq 'group-stage') {
     $prefix = grey("[" . $group->{name} . "] ");
   } else {
     $prefix = grey("[$round] ");


### PR DESCRIPTION
Now that the tournament is in the knockout rounds, !wc \<team\> was still
showing the team's original group letter (e.g. [Group E] Paraguay vs Germany)
instead of the current round. This is especially confusing when searching
two teams in the same match shows different groups.

Changes:
- **renderTeamGame**: only show [Group X] prefix when season slug is
  `group-stage`; otherwise show the round label (R32, R16, QF, SF, etc.)
- **Last/Next fallback**: each event now computes its own round prefix
  from its own season slug and displays it inline with that event,
  rather than using a single global prefix for the combined line.
- **Season priority**: prefer the next event's season over the last's
  when determining which season to reference, since the upcoming match
  is what users care about.

Example outputs:
- Live knockout game: `[R32] Paraguay 0-0 Germany LIVE 7'`
- Team with last group game + upcoming knockout:
  `[Group D] Last (Jun 26): USA 2-3 TUR · [R32] Next (Jul 2): Bosnia-Herzegovina vs United States`
- Eliminated team: `[Group D] Last (Jun 26): USA 2-3 TUR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)