### PR TITLE
worldcup: handle break between periods + extra time halftime in knockout matches

### DIFF
--- a/lib/worldcup
+++ b/lib/worldcup
@@ -162,6 +162,8 @@ sub statusLabel {
     return yellow("LIVE") . " $clock";
   } elsif ($typeName eq 'STATUS_HALFTIME') {
     return yellow('HT');
+  } elsif ($typeName eq 'STATUS_HALFTIME_ET') {
+    return yellow('HT') . " $clock";
   } elsif ($typeName eq 'STATUS_FULL_TIME') {
     return yellow('FT');
   } elsif ($typeName eq 'STATUS_FULL_EXTRA') {
@@ -191,7 +193,8 @@ sub isLive {
   my $name = shift // '';
   return $name eq 'STATUS_IN_PROGRESS' || $name eq 'STATUS_HALFTIME'
       || $name eq 'STATUS_OVERTIME'    || $name eq 'STATUS_PENALTY'
-      || $name eq 'STATUS_FIRST_HALF'  || $name eq 'STATUS_SECOND_HALF';
+      || $name eq 'STATUS_FIRST_HALF'  || $name eq 'STATUS_SECOND_HALF'
+      || $name eq 'STATUS_HALFTIME_ET';
 }
 
 sub isFinal {


### PR DESCRIPTION
Two fixes for knockout matches that go to extra time:

**1. Between-periods break:** `STATUS_FULL_TIME` and `STATUS_FULL_EXTRA` were treated as final results by `isFinal()`, but in knockout matches with a tied score the game is still going — it's just the break between regulation and extra time (or extra time and penalties). During this window the bot showed the match as "(FT)" and dropped stats/cards/commentary. Added `isBetweenPeriods()` to detect these transitional states and display the match as ongoing with full detail and yellow labels.

**2. Extra time halftime:** ESPN uses `STATUS_HALFTIME_ET` (not `STATUS_HALFTIME`) for the break between the two halves of extra time. This status wasn't in `isLive()`, so the match fell through to the scheduled/preview branch and showed as if it hadn't started yet. Added to `isLive()` and `statusLabel()`.

Group stage draws are unaffected — those are truly final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)