### PR TITLE
scores: include entry category in output

### DIFF
--- a/botcommands.md
+++ b/botcommands.md
@@ -949,7 +949,9 @@ Example:
 ### `!scores` -- look up a callsign on Contest Online ScoreBoard (COSB)
 
 Searches all currently active contests on contestonlinescore.com for the given
-callsign and reports rank, score, and QSO count for each contest found.
+callsign and reports rank, entry category, score, and QSO count for each contest
+found.  The rank is the position within that category, as COSB groups the
+scoreboard by category.
 
 Usage:
 
@@ -961,10 +963,10 @@ Examples:
 
 ```
     <W0NY> !scores AA3B
-    <qrm> COSB [CQ WPX CW]: AA3B #10 | Score: 8289099 | QSOs: 2693
+    <qrm> COSB [CQ WPX CW]: AA3B #10 | SO-ALL HP | Score: 8289099 | QSOs: 2693
 
     <W0NY> !scores N3RD
-    <qrm> COSB [CQ WPX CW]: N3RD #249 | Score: 53808 | QSOs: 126
+    <qrm> COSB [CQ WPX CW]: N3RD #249 | SO-ALL LP (A) | Score: 53808 | QSOs: 126
 
     <W0NY> !scores W1AW
     <qrm> W1AW not found in active COSB contest(s): CQ WPX CW
@@ -975,8 +977,8 @@ overlapping sprints), each match is reported on its own line:
 
 ```
     <W0NY> !scores AA3B
-    <qrm> COSB [CWops Mini-CWT 1]: AA3B #3 | Score: 4182 | QSOs: 66
-    <qrm> COSB [NCCC NA CW Sprint]: AA3B #7 | Score: 1820 | QSOs: 52
+    <qrm> COSB [CWops Mini-CWT 1]: AA3B #3 | SO-ALL LP | Score: 4182 | QSOs: 66
+    <qrm> COSB [NCCC NA CW Sprint]: AA3B #7 | SO-ALL LP | Score: 1820 | QSOs: 52
 ```
 
 If no contests are currently active:

--- a/lib/scores
+++ b/lib/scores
@@ -82,6 +82,26 @@ foreach my $contest (@active) {
 
   my $row = substr($html, $tr_pos, $tr_end - $tr_pos + 5);
 
+  # Category: the board is grouped into sections, each introduced by a
+  # <tr class="title5"> header naming the category, e.g. "SO-ALL LP (A) CW".
+  # The applicable one is the last such header before this entry's row.
+  my $category;
+  {
+    my $prefix = substr($html, 0, $tr_pos);
+    my $hdr;
+    while ($prefix =~ m|<tr[^>]*class=['"]title5['"][^>]*>(.*?)</td>|gis) {
+      $hdr = $1;
+    }
+    if (defined $hdr) {
+      $hdr =~ s/^.*?<td[^>]*>//s;   # keep only the header cell's contents
+      $hdr =~ s/<[^>]*>//g;         # strip the per-category filter links
+      $hdr =~ s/&nbsp;/ /g;
+      $hdr =~ s/\s+/ /g;
+      $hdr =~ s/^\s+|\s+$//g;
+      $category = $hdr if $hdr ne "";
+    }
+  }
+
   # Rank: first numeric <td> content
   my $rank;
   $rank = $1 if $row =~ m|<td[^>]*>(\d+)|i;
@@ -104,8 +124,10 @@ foreach my $contest (@active) {
   next unless defined $qsos;
   $qsos =~ s/,//g;
 
+  my $catstr = defined $category ? " | $category" : "";
+
   print "COSB [" . bold($contest->{name}) . "]: " . bold($call) .
-        " #$rank | Score: $score | QSOs: $qsos\n";
+        " #$rank$catstr | Score: $score | QSOs: $qsos\n";
   $found = 1;
 }
 


### PR DESCRIPTION
`!scores` prints a rank, but COSB groups its scoreboard into sections by category, so that rank is a rank *within a category*. Without naming the category the number is ambiguous — two callsigns can both be `#1`:

```
COSB [NAQP CW]: AA3B #1 | SO-ALL LP (A) CW | Score: 365024 | QSOs: 1342
COSB [NAQP CW]: N4ML #1 | M/2 LP | Score: 406032 | QSOs: 1539
```

This takes the category from the last `<tr class="title5">` section header preceding the entry's row, strips the per-category filter links out of it, and prints it after the rank. If no section header is found the field is omitted and output is unchanged.

Before:

```
COSB [NAQP CW]: W0NY #86 | Score: 53875 | QSOs: 431
```

After:

```
COSB [NAQP CW]: W0NY #86 | SO-ALL LP (A) CW | Score: 53875 | QSOs: 431
```

Tested against the live board during NAQP CW (single-op, multi-two, and a not-found callsign); `botcommands.md` examples updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)