### PR TITLE
scores: search recently closed contests too, flag them as such

### DIFF
--- a/botcommands.md
+++ b/botcommands.md
@@ -948,10 +948,12 @@ Example:
 
 ### `!scores` -- look up a callsign on Contest Online ScoreBoard (COSB)
 
-Searches all currently active contests on contestonlinescore.com for the given
-callsign and reports rank, entry category, score, and QSO count for each contest
-found.  The rank is the position within that category, as COSB groups the
-scoreboard by category.
+Searches all currently active contests on contestonlinescore.com -- plus the
+recently closed ones COSB still lists, for a few days after a contest ends --
+for the given callsign, and reports rank, entry category, score, and QSO count
+for each contest found.  The rank is the position within that category, as COSB
+groups the scoreboard by category.  Results from a contest that has finished are
+flagged `(closed)`.
 
 Usage:
 
@@ -969,7 +971,15 @@ Examples:
     <qrm> COSB [CQ WPX CW]: N3RD #249 | SO-ALL LP (A) | Score: 53808 | QSOs: 126
 
     <W0NY> !scores W1AW
-    <qrm> W1AW not found in active COSB contest(s): CQ WPX CW
+    <qrm> W1AW not found in active COSB contest(s): CQ WPX CW; or recently
+          closed: NCCC NA CW Sprint
+```
+
+A contest that has already finished is still reported, flagged `(closed)`:
+
+```
+    <W0NY> !scores W0NY
+    <qrm> COSB [NAQP CW] (closed): W0NY #76 | SO-ALL LP (A) CW | Score: 78768 | QSOs: 547
 ```
 
 If the callsign is active in more than one contest (e.g. a CWT day with
@@ -981,11 +991,11 @@ overlapping sprints), each match is reported on its own line:
     <qrm> COSB [NCCC NA CW Sprint]: AA3B #7 | SO-ALL LP | Score: 1820 | QSOs: 52
 ```
 
-If no contests are currently active:
+If COSB lists no contests at all, on air or recently closed:
 
 ```
     <W0NY> !scores AA3B
-    <qrm> No contests currently on air at COSB.
+    <qrm> No contests currently on air or recently closed at COSB.
 ```
 
 Data source: https://contestonlinescore.com/

--- a/lib/scores
+++ b/lib/scores
@@ -37,8 +37,10 @@ my $call = uc $ARGV[0];
 
 my $base = "https://contestonlinescore.com/scoreboard/";
 
-# Fetch main page and find all "On air" contest IDs and names
-my @active;
+# Fetch main page and find all "On air" and recently "Closed" contest IDs and
+# names.  COSB drops a contest from the list a few days after it ends, so the
+# closed ones are the results people are still asking about.
+my @contests;
 {
   my $html = "";
   open(HTTP, '-|', "curl --max-time 15 -skL -A 'eggdrop-cosb-bot/1.0' '$base'");
@@ -47,20 +49,23 @@ my @active;
   $html = <HTTP>;
   close(HTTP);
 
-  while ($html =~ m|<option[^>]*value=['"](\d+)['"][^>]*>On air:\s*([^<]+)</option>|gi) {
-    my ($id, $name) = ($1, $2);
+  while ($html =~ m{<option[^>]*value=['"](\d+)['"][^>]*>(On air|Closed):\s*([^<]+)</option>}gi) {
+    my ($id, $state, $name) = ($1, $2, $3);
     $name =~ s/\s+$//;
-    push @active, { id => $id, name => $name };
+    push @contests, { id => $id, name => $name, closed => ($state =~ /^closed$/i) ? 1 : 0 };
   }
+
+  # report contests still running before ones that have finished
+  @contests = ((grep { !$_->{closed} } @contests), (grep { $_->{closed} } @contests));
 }
 
-if (scalar @active == 0) {
-  print "No contests currently on air at COSB.\n";
+if (scalar @contests == 0) {
+  print "No contests currently on air or recently closed at COSB.\n";
   exit 0;
 }
 
 my $found = 0;
-foreach my $contest (@active) {
+foreach my $contest (@contests) {
   my $url = "${base}?contest_id=$contest->{id}";
   my $html = "";
   open(HTTP, '-|', "curl --max-time 15 -skL -A 'eggdrop-cosb-bot/1.0' '$url'");
@@ -125,14 +130,23 @@ foreach my $contest (@active) {
   $qsos =~ s/,//g;
 
   my $catstr = defined $category ? " | $category" : "";
+  my $closedstr = $contest->{closed} ? " " . grey("(closed)") : "";
 
-  print "COSB [" . bold($contest->{name}) . "]: " . bold($call) .
+  print "COSB [" . bold($contest->{name}) . "]$closedstr: " . bold($call) .
         " #$rank$catstr | Score: $score | QSOs: $qsos\n";
   $found = 1;
 }
 
 if (!$found) {
-  my @names = map { $_->{name} } @active;
-  print bold($call) . " not found in active COSB contest(s): " .
-        join(", ", @names) . "\n";
+  my @active = map { $_->{name} } grep { !$_->{closed} } @contests;
+  my @closed = map { $_->{name} } grep { $_->{closed} } @contests;
+
+  my $msg = bold($call) . " not found in";
+  if (scalar @active > 0) {
+    $msg .= " active COSB contest(s): " . join(", ", @active);
+    $msg .= "; or recently closed: " . join(", ", @closed) if scalar @closed > 0;
+  } else {
+    $msg .= " recently closed COSB contest(s): " . join(", ", @closed);
+  }
+  print "$msg\n";
 }


### PR DESCRIPTION
Stacked on #170 — that PR's commit is included here; the new work is the second commit, `scores: search recently closed contests too`. Merging #170 first will reduce this to a single commit.

COSB keeps a contest on its selector for a few days after it ends, and the minutes right after a contest is exactly when people want to look up a score. `!scores` only scanned `On air:` entries, so a lookup just after the final bell reported nothing found.

This also collects the `Closed:` entries, searches them after the active ones, and marks those results so a stale score is never mistaken for a live one:

```
COSB [NAQP CW] (closed): W0NY #76 | SO-ALL LP (A) CW | Score: 78768 | QSOs: 547
```

The `(closed)` flag is greyed on IRC. The not-found message now covers both sets:

```
ZZ9ZZZ not found in active COSB contest(s): 10-10 Int. Summer SSB, CQ RJ VHF,
ARRL 222 MHz and Up; or recently closed: K1USN Slow Speed Fri, European HF
Championship, NAQP CW
```

Cost is one extra fetch per closed contest — 5 listed at the time of testing, ~0.4s each, and they're only fetched when the command runs.

Tested live today against COSB, including the NAQP CW board after it closed (the example above is the real output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)