### PR TITLE
fix shell injection, crashes, and logic bugs

### DIFF
--- a/lib/Util.pm
+++ b/lib/Util.pm
@@ -12,7 +12,7 @@ use feature 'unicode_strings';
 
 require Exporter;
 @ISA = qw(Exporter);
-@EXPORT = qw(decodeEntities stripIrcColors getFullWeekendInMonth getIterDayInMonth getYearForDate monthNameToNum commify humanNum moveFile shortenUrl isNumeric arraysEqual getEggdropUID getDxccDataRef updateCty checkCtyDat checkMW scrapeMW);
+@EXPORT = qw(decodeEntities stripIrcColors getFullWeekendInMonth getIterDayInMonth getYearForDate monthNameToNum commify humanNum moveFile shortenUrl isNumeric arraysEqual getEggdropUID getDxccDataRef updateCty checkCtyDat checkMW scrapeMW shellQuote);
 
 use URI::Escape;
 use Date::Manip;
@@ -20,6 +20,14 @@ use Math::Round;
 use File::Temp qw(tempfile);
 use File::Copy;
 use JSON qw( from_json );
+
+# safely quote a string for use as a single shell argument
+sub shellQuote {
+  my $s = shift;
+  return "''" if not defined $s;
+  $s =~ s/'/'\\''/g;
+  return "'$s'";
+}
 
 sub decodeEntities {
   my $s = shift;
@@ -376,8 +384,8 @@ sub shortenUrl {
 	  "curl --max-time $timeout -L -k -s " .
 	  "-H 'Content-Type: application/json' " .
 	  "-H 'Authorization: Bearer $bitly_apikey' " .
-	  "-X POST --data '$requestdoc' ".
-	  "'$rest'");
+	  "-X POST --data " . shellQuote($requestdoc) . " " .
+	  shellQuote($rest));
   binmode(HTTP, ":utf8");
   while(<HTTP>) {
     $shortUrl = $1 if /"link":\s*"(.*?)"/;
@@ -400,6 +408,7 @@ sub isNumeric {
     return $val =~ /^-?[0-9]+\.?[0-9]*$/ ? 1 : 0;
   } else {
     warn "isNumeric requires an argument!";
+    return 0;
   }
 }
 

--- a/lib/adsb
+++ b/lib/adsb
@@ -520,7 +520,7 @@ sub getFlightTrack
 {
   my $flight = shift;
   our $scrapingant_key;
-  my $url = "https://flightaware.com/live/flight/$flight";
+  my $url = "https://flightaware.com/live/flight/" . uri_escape($flight);
 
   if (defined $scrapingant_key) {
     $url = "https://api.scrapingant.com/v2/general?url=". uri_escape($url) . "&x-api-key=${scrapingant_key}&browser=false";
@@ -528,7 +528,7 @@ sub getFlightTrack
   my ($airline, $orig, $dest, $fnum, $eta);
   my $token;
   #print "$url\n";
-  open(HTTP, '-|', "curl --stderr - --max-time 10 -s -k -L '$url'");
+  open(HTTP, '-|', "curl --stderr - --max-time 10 -s -k -L " . shellQuote($url));
   while(<HTTP>) {
     if (/name="origin".*content="([A-Z]+)"/) {
       $orig = $1;

--- a/lib/aqi
+++ b/lib/aqi
@@ -109,7 +109,11 @@ sub getNearest {
   binmode(JSON, ":utf8");
   my $json = <JSON>;
   close(JSON);
-  my $j = from_json($json) or die "error: could not decode response\n";
+  if (not $json =~ /^\s*{/) {
+    print "error: could not fetch data\n";
+    exit $exitnonzeroonerror;
+  }
+  my $j = from_json($json);
 
   if (defined $j->{'aqMonitors'}->[0]) {
 

--- a/lib/debt
+++ b/lib/debt
@@ -76,8 +76,8 @@ if ($json =~ /Sorry, you have been blocked/) {
   goto SKIP_POP_PARSE;
 }
 
-if (length($json) > 0) {
-  $j = decode_json($json) or die "parse error: $json\n";
+if (length($json) > 0 and $json =~ /^\s*{/) {
+  $j = decode_json($json);
 }
 
 if (defined $j->{detail}) {

--- a/lib/fest
+++ b/lib/fest
@@ -196,7 +196,7 @@ if (@events == 0) {
 @events = sort {
   my ($am, $ad, $ay) = split('/', $a->{date});
   my ($bm, $bd, $by) = split('/', $b->{date});
-  "$ay$am$ad" cmp "$by$bm$bd"
+  sprintf("%04d%02d%02d", $ay, $am, $ad) cmp sprintf("%04d%02d%02d", $by, $bm, $bd)
 } @events;
 
 if (@events == 0) {

--- a/lib/gasprice
+++ b/lib/gasprice
@@ -113,7 +113,11 @@ if ($json =~ /(Cloudflare|challenge-error-text)/) {
   print "Error: unable to retrieve station list (Cloudflare)\n";
   exit $exitnonzeroonerror;
 }
-my $j = decode_json($json) or die "parse error: $json\n";
+if (not $json =~ /^\s*{/) {
+  print "Error: unable to retrieve station list\n";
+  exit $exitnonzeroonerror;
+}
+my $j = decode_json($json);
 #print $json, "\n";
 
 my $stationsref = [];
@@ -125,7 +129,7 @@ for ($m = 0, $n = 0; $m < scalar (@{$j->{primaryStations}}); $m++, $n++) {
   #print "$m -> $n\n";
 }
 for ($m = 0; $m < scalar (@{$j->{secondaryStations}}); $m++, $n++) {
-  $stationsref->[$n] = $j->{primaryStations}->[$m];
+  $stationsref->[$n] = $j->{secondaryStations}->[$m];
   #print "$m -> $n\n";
 }
 

--- a/lib/iono
+++ b/lib/iono
@@ -71,6 +71,11 @@ if (defined $query and not defined $result) {
 my ($mylat, $mylon) = split(',', $geo) if defined $geo;
 ($mylat, $mylon) = split(',', $result) if defined $result;
 
+if (defined $geo and (not isNumeric($mylat) or not isNumeric($mylon))) {
+  print "error: invalid --geo value\n";
+  exit $exitnonzeroonerror;
+}
+
 #print "$mylat, $mylon\n";
 
 my $url = "https://prop.kc2g.com/api/stations.json";

--- a/lib/linksummary
+++ b/lib/linksummary
@@ -528,7 +528,7 @@ sub doMastodon {
 
   INSTANCE_CHECK:
   my $instanceapi = "${instance_base}/api/v1/instance";
-  open(JSON, '-|', "curl --max-time $timeout -L -k -s '$instanceapi' ");
+  open(JSON, '-|', "curl --max-time $timeout -L -k -s " . shellQuote($instanceapi));
   local $/;   # read entire file -- FIXME: potentially memory hungry
   my $uri = <JSON>;
   close(JSON);
@@ -546,7 +546,7 @@ sub doMastodon {
 
   my $apiurl = "${instance_base}/api/v1/statuses/$statusid";
   #print "apiurl: $apiurl\n";
-  open(JSON, '-|', "curl --max-time $timeout -L -k -s '$apiurl'");
+  open(JSON, '-|', "curl --max-time $timeout -L -k -s " . shellQuote($apiurl));
   binmode(JSON, ":utf8");
   local $/;   # read entire file -- FIXME: potentially memory hungry
   my $json = <JSON>;
@@ -816,7 +816,7 @@ sub doHtml {
   #print "curl --compressed --max-time $timeout -D - -f -L -k -s -H \"Accept: text/html,application/xhtml+xml,application/xml;q=0.9\" '$url'";
   my $useragent = "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0";
   #print("curl --compressed --max-time $timeout -D - -f -L -k -s -H \"Accept: text/html,application/xhtml+xml,application/xml;q=1.9\" -A \"$useragent\" '$url'");
-  open (HTTP, '-|', "curl --compressed --max-time $timeout -D - -f -L -k -s -H \"Accept: text/html,text/plain,application/xhtml+xml,application/xml;q=1.9\" -H \"Accept-Language: en-us, en;q=0.9, *;q=0.8\" -A \"$useragent\" '$url'");
+  open (HTTP, '-|', "curl --compressed --max-time $timeout -D - -f -L -k -s -H \"Accept: text/html,text/plain,application/xhtml+xml,application/xml;q=1.9\" -H \"Accept-Language: en-us, en;q=0.9, *;q=0.8\" -A \"$useragent\" " . shellQuote($url));
   while (<HTTP>) {
     #print;
     chomp;

--- a/lib/longtermforecast
+++ b/lib/longtermforecast
@@ -84,7 +84,9 @@ $minsfi = 10000000.0;
 my $maxap = -1.0;
 my $minap = 10000.0;
 
-while (not $found) {
+my $tries = 0;
+while (not $found and $tries < 24) {
+  $tries++;
 
   my $currmonth = lc strftime("%b%Y", gmtime $time);
   my $curr_y_m = strftime("%Y/%m", gmtime $time);
@@ -131,6 +133,8 @@ if ($found) {
   printf "NASA:%s\n", yearMarkers(sort keys %sfi);
   printf "SFI: %s : $minsfi-$maxsfi\n", join("", sfiToColorBlocks($minsfi, $maxsfi, \%sfi));
   printf "AP:  %s : $minap-$maxap\n", join("", apToColorBlocks($minap, $maxap, \%ap));
+} else {
+  print "error: unable to find forecast data\n";
 }
 
 $url = "https://www.itu.int/ITU-R/eTerrestrial/eBroadcasting/eHFBC/api/hfbc/reftables/tables/sunspots";

--- a/lib/lotwstatus
+++ b/lib/lotwstatus
@@ -29,6 +29,10 @@ binmode(HTTP, ":utf8");
 local $/;   # read entire file -- FIXME: potentially memory hungry
 my $json = <HTTP>;
 close HTTP;
+if (not $json =~ /^\s*{/) {
+  print "error: could not fetch data\n";
+  exit 1;
+}
 my $j = decode_json($json);
 $isup = $j->{statistics}->{counts}->{down} == 0;
 $uptime = $j->{data}[0]{'30dRatio'}{ratio};

--- a/lib/pota
+++ b/lib/pota
@@ -114,18 +114,18 @@ if ($count > 1 and uc @{$j}[0]->{value} ne uc $term) {
   if (@{$j}[0]->{type} eq "park") {
     #print "park: ", $srec->{display}, " -- TODO\n";
     # TODO
-    my $url = "https://api.pota.app/park/" . $srec->{value};
+    my $url = "https://api.pota.app/park/" . uri_escape($srec->{value});
 
     local $/;   # read entire file -- FIXME: potentially memory hungry
-    open(JSON, '-|', "curl -k -L --max-time 10 --retry 1 -s '$url'");
+    open(JSON, '-|', "curl -k -L --max-time 10 --retry 1 -s " . shellQuote($url));
     my $json = <JSON>;
     close(JSON);
     #print $json, "\n";
     my $j = decode_json($json);
 
-    my $url = "https://api.pota.app/park/stats/" . $srec->{value};
+    my $url = "https://api.pota.app/park/stats/" . uri_escape($srec->{value});
     local $/;   # read entire file -- FIXME: potentially memory hungry
-    open(JSON, '-|', "curl -k -L --max-time 10 --retry 1 -s '$url'");
+    open(JSON, '-|', "curl -k -L --max-time 10 --retry 1 -s " . shellQuote($url));
     my $json = <JSON>;
     close(JSON);
     #print $json, "\n";
@@ -138,9 +138,9 @@ if ($count > 1 and uc @{$j}[0]->{value} ne uc $term) {
       $k = decode_json($json);
     }
 
-    my $url = "https://api.pota.app/park/activations/$srec->{value}?count=1";
+    my $url = "https://api.pota.app/park/activations/" . uri_escape($srec->{value}) . "?count=1";
     local $/;   # read entire file -- FIXME: potentially memory hungry
-    open(JSON, '-|', "curl -k -L --max-time 10 --retry 1 -s '$url'");
+    open(JSON, '-|', "curl -k -L --max-time 10 --retry 1 -s " . shellQuote($url));
     my $json = <JSON>;
     close(JSON);
     #print $json, "\n";
@@ -165,9 +165,9 @@ if ($count > 1 and uc @{$j}[0]->{value} ne uc $term) {
 	$last->{activeCallsign},
 	commify($last->{totalQSOs});
 
-      my $url = "https://api.pota.app/park/leaderboard/$srec->{value}?count=3";
+      my $url = "https://api.pota.app/park/leaderboard/" . uri_escape($srec->{value}) . "?count=3";
       local $/;   # read entire file -- FIXME: potentially memory hungry
-      open(JSON, '-|', "curl -k -L --max-time 10 --retry 1 -s '$url'");
+      open(JSON, '-|', "curl -k -L --max-time 10 --retry 1 -s " . shellQuote($url));
       my $json = <JSON>;
       close(JSON);
       #print $json, "\n";
@@ -199,10 +199,10 @@ if ($count > 1 and uc @{$j}[0]->{value} ne uc $term) {
 
   } elsif (@{$j}[0]->{type} eq "user") {
     #print "user\n";
-    my $url = "https://api.pota.app/profile/" . $srec->{value};
+    my $url = "https://api.pota.app/profile/" . uri_escape($srec->{value});
 
     local $/;   # read entire file -- FIXME: potentially memory hungry
-    open(JSON, '-|', "curl -k -L --max-time 10 --retry 1 -s '$url'");
+    open(JSON, '-|', "curl -k -L --max-time 10 --retry 1 -s " . shellQuote($url));
     my $json = <JSON>;
     close(JSON);
     #print $json, "\n";

--- a/lib/potapark
+++ b/lib/potapark
@@ -121,6 +121,10 @@ open(JSON, '-|', "curl -k -L --max-time 10 --retry 1 -s '$url'");
 my $json = <JSON>;
 close(JSON);
 
+if (not $json =~ /^\s*{/) {
+  print "error: could not fetch data\n";
+  exit $exitnonzeroonerror;
+}
 my $j = decode_json($json);
 
 my %results;

--- a/lib/repeater
+++ b/lib/repeater
@@ -43,7 +43,7 @@ while ($i <= $#ARGV) {
     $i++;
     next;
   }
-  if ($ARGV[$i] =~ /^((10|6|4|2|1\.25)m)|((70|33|23)cm)$/) {
+  if ($ARGV[$i] =~ /^((10|6|4|2|1\.25)m|(70|33|23)cm)$/) {
     $band = $ARGV[$i];
     $i++;
     next;
@@ -60,7 +60,7 @@ my $encoded = uri_escape($searchterm);
 my $url = "https://repeaterbook.com/repeaters/keyword.php?func=result&keyword=${encoded}&state_id=0";
 #print "$url\n";
 
-if (defined($band) and !($band =~ /^((10|6|4|2|1\.25)m)|((70|33|23)cm)$/)) {
+if (defined($band) and !($band =~ /^((10|6|4|2|1\.25)m|(70|33|23)cm)$/)) {
   print "valid bands: 10m 6m 4m 2m 1.25m 70cm 33cm 23cm\n";
   exit 0;
 }

--- a/lib/scores
+++ b/lib/scores
@@ -75,8 +75,10 @@ foreach my $contest (@contests) {
   close(HTTP);
 
   # Find the rate link for this call, then extract its enclosing <tr>
+  # (must not match a longer callsign that starts with this one)
   my $lcall = lc $call;
-  my $link_pos = index(lc $html, "call=$lcall");
+  my $link_pos = -1;
+  $link_pos = $-[0] if lc($html) =~ /call=\Q$lcall\E(?![a-z0-9])/;
   next if $link_pos < 0;
 
   my $tr_pos = rindex($html, "<tr", $link_pos);
@@ -113,7 +115,8 @@ foreach my $contest (@contests) {
   next unless defined $rank;
 
   # Position after the callsign cell's </td>
-  my $call_in_row = index(lc $row, "call=$lcall");
+  my $call_in_row = -1;
+  $call_in_row = $-[0] if lc($row) =~ /call=\Q$lcall\E(?![a-z0-9])/;
   my $after_td = index($row, "</td>", $call_in_row) + 5;
   my $after_call = substr($row, $after_td);
 

--- a/lib/scrape-nicks.pl
+++ b/lib/scrape-nicks.pl
@@ -155,7 +155,7 @@ foreach my $baseurl (@baseurls) {
     local $/;   # read entire file -- FIXME: potentially memory hungry
     my $json = <HTTP>;
     close(HTTP);
-    if (not defined $json or $json eq "") {
+    if (not defined $json or not $json =~ /^\s*[{\[]/) {
       print "WARNING: skipping $url\n";
       next;
     }

--- a/lib/translate
+++ b/lib/translate
@@ -349,6 +349,10 @@ sub do_deepl {
   my $json = <HTTP>;
   close(HTTP);
   #print ("$json\n");
+  if (not $json =~ /^\s*{/) {
+    print "DEEPL error: could not fetch data\n";
+    return 0;
+  }
   my $j = decode_json($json); # includes utf-8 decode
 
   if (defined $j->{translations} and defined $j->{translations}->[0]) {
@@ -387,6 +391,10 @@ sub do_google {
   my $json = <HTTP>;
   close(HTTP);
   #print ("$json\n");
+  if (not $json =~ /^\s*{/) {
+    print "GOOGLE error: could not fetch data\n";
+    return 0;
+  }
   my $j = decode_json($json); # includes utf-8 decode
 
   if (defined $j->{data}->{translations} and

--- a/lib/ud
+++ b/lib/ud
@@ -45,6 +45,10 @@ my $json = <JSON>;
 close(JSON);
 
 #print $json, "\n";
+if (not $json =~ /^\s*{/) {
+  print "error: could not fetch data\n";
+  exit $exitnonzeroonerror;
+}
 my $j = decode_json($json);
 
 if (not defined $j->{list}->[0]) {

--- a/scripts/band.tcl
+++ b/scripts/band.tcl
@@ -56,12 +56,17 @@ proc b_pubquote { nick uhost hand chan arg } {
 
     if { $tmp == 0 } {
       putchan $chan "no bands recorded"
+      close $qf
       return
     }
 
     if { [string trim "$arg"] == "" } {
       set j [rand $tmp]
       #putmsg "$nick" "picked band [expr $j + 1] of $tmp"
+    } elseif { ! [string is integer -strict [string trim "$arg"]] } {
+      putmsg "$nick" "valid band number from 1 to $tmp"
+      close $qf
+      return
     } else {
       set j "$arg"
       if { ( $j >= 1 ) && ( $j <= $tmp ) } {

--- a/scripts/hofh.tcl
+++ b/scripts/hofh.tcl
@@ -53,12 +53,17 @@ proc h_pubquote { nick uhost hand chan arg } {
 
     if { $tmp == 0 } {
       putchan $chan "no hofh recorded"
+      close $qf
       return
     }
 
     if { [string trim "$arg"] == "" } {
       set j [rand $tmp]
       #putmsg "$nick" "picked hofh [expr $j + 1] of $tmp"
+    } elseif { ! [string is integer -strict [string trim "$arg"]] } {
+      putmsg "$nick" "valid hofh number from 1 to $tmp"
+      close $qf
+      return
     } else {
       set j "$arg"
       if { ( $j >= 1 ) && ( $j <= $tmp ) } {

--- a/scripts/qrzgrid.tcl
+++ b/scripts/qrzgrid.tcl
@@ -2305,7 +2305,7 @@ proc potaleague_pub { nick host hand chan text } {
 	global potaleaguebin
 	set params [sanitize_string [string trim "${text}"]]
 	putlog "potaleague pub: $nick $host $hand $chan $params"
-	set fd [open "|${potaleaguebin} --channel ${chan} ${params}" r]
+	set fd [open "|${potaleaguebin} --channel [sanitize_string ${chan}] ${params}" r]
 	fconfigure $fd -encoding utf-8
 	while {[gets $fd line] >= 0} {
 		putchan $chan "$line"
@@ -2332,7 +2332,7 @@ proc potaleagueadd_pub { nick host hand chan text } {
 		putchan $chan "usage: !potaleagueadd <callsign>"
 		return
 	}
-	set fd [open "|${potaleaguebin} --channel ${chan} --register ${call}" r]
+	set fd [open "|${potaleaguebin} --channel [sanitize_string ${chan}] --register ${call}" r]
 	fconfigure $fd -encoding utf-8
 	while {[gets $fd line] >= 0} {
 		putchan $chan "$line"
@@ -2363,7 +2363,7 @@ proc potaleaguedel_pub { nick host hand chan text } {
 		putchan $chan "usage: !potaleaguedel <callsign>"
 		return
 	}
-	set fd [open "|${potaleaguebin} --channel ${chan} --remove ${call}" r]
+	set fd [open "|${potaleaguebin} --channel [sanitize_string ${chan}] --remove ${call}" r]
 	fconfigure $fd -encoding utf-8
 	while {[gets $fd line] >= 0} {
 		putchan $chan "$line"

--- a/scripts/quotes.tcl
+++ b/scripts/quotes.tcl
@@ -57,6 +57,7 @@ proc q_pubquote { nick uhost hand chan arg } {
 
     if { $tmp == 0 } {
       putchan $chan "no quotes recorded for $chan"
+      close $qf
       return
     }
 


### PR DESCRIPTION
- add Util::shellQuote and use it for curl calls built from remote/scraped data (shortenUrl, adsb, pota, linksummary)
- iono: validate --geo is numeric before use
- qrzgrid.tcl: sanitize channel name in potaleague handlers
- guard decode_json/from_json calls against bad input (ud, potapark, lotwstatus, aqi, debt, translate, scrape-nicks.pl)
- longtermforecast: cap retry loop, no more infinite hang
- repeater: fix regex grouping so band match anchors correctly
- fest: zero-pad date sort keys for correct chronological order
- gasprice: fix copy-paste bug dropping secondary stations
- scores: require exact callsign match, not prefix substring
- hofh.tcl/band.tcl/quotes.tcl: close file handles on early return, validate numeric input

