### PR TITLE
nfl: show national TV network

### DIFF
--- a/botcommands.md
+++ b/botcommands.md
@@ -1375,9 +1375,9 @@ or common nickname (`niners`, `vikes`). Team aliases (e.g. `!eagles`,
 `!bucs`, `!cardinals` are taken by `!nhl`/`!mlb` aliases — use `!nfl <name>`
 for those teams.)
 
-Covers live games (score, quarter, clock, down/distance, last play), final
-games (score), postponed games, and off days (record + division standing +
-next game).
+Covers live games (score, quarter, clock, down/distance, last play, national
+TV network), final games (score), postponed games, and off days (record +
+division standing + next game).
 
 Data source: https://site.web.api.espn.com/apis/site/v2/sports/football/nfl/
 

--- a/lib/nfl
+++ b/lib/nfl
@@ -241,10 +241,20 @@ sub getGame {
   my $comp = $ev->{competitions}[0] // {};
   my $status = $ev->{status} // $comp->{status} // {};
   my $type = $status->{type} // {};
-  my ($away, $home);
+  my ($away, $home, $tv);
   foreach my $c (@{$comp->{competitors} // []}) {
     if (($c->{homeAway} // '') eq 'home') { $home = $c }
     elsif (($c->{homeAway} // '') eq 'away') { $away = $c }
+  }
+  # national TV network; broadcast shapes differ between the schedule
+  # (market:{type}, media.shortName) and scoreboard (market, names[]) endpoints
+  foreach my $b (@{$comp->{broadcasts} // []}) {
+    my $mkt = $b->{market} // '';
+    $mkt = ref($mkt) eq 'HASH' ? ($mkt->{type} // '') : $mkt;
+    next unless lc($mkt) eq 'national';
+    $tv = $b->{media}{shortName} // '';
+    $tv = $b->{names}[0] // '' if !$tv && ref($b->{names}) eq 'ARRAY';
+    last if $tv;
   }
   return {
     date     => $ev->{date} // '',
@@ -252,6 +262,7 @@ sub getGame {
     state    => $type->{state} // '',
     detail   => $type->{detail} // '',
     short    => $type->{shortDetail} // '',
+    tv       => $tv,
     clock    => $status->{displayClock} // '',
     period   => $status->{period} // 0,
     away     => $away,
@@ -329,6 +340,7 @@ sub gameSnippet {
   my $time = fmtStartTime($g->{short});
   my $s = teamColor(tabbr($g->{away})) . " @ " . teamColor(tabbr($g->{home}));
   $s .= " $time" if $time;
+  $s .= grey(" on $g->{tv}") if $g->{tv};
   return $s;
 }
 
@@ -351,14 +363,14 @@ sub renderTeamLine {
     my $ql = quarterLabel($g->{period}, $g->{clock});
     my $status = $ql ? ($ql eq 'Halftime' ? yellow('Halftime') : yellow("$ql $g->{clock}")) : ($g->{short} ? yellow($g->{short}) : yellow('LIVE'));
     push @parts, $status;
+    push @parts, grey("on $g->{tv}") if $g->{tv};
     my $sit = $g->{comp}{situation} // {};
     if (ref($sit) eq 'HASH' && ($sit->{down} // 0) > 0) {
       my $dnt = $sit->{shortDownDistanceText} // $sit->{downDistanceText} // '';
-      my $pos = $sit->{possessionText} // '';
-      my $yl  = $sit->{yardLine};
+      my $pos = $sit->{possessionText} // '';   # already includes yard line, e.g. "PIT 36"
       if ($dnt) {
         my $sitStr = $dnt;
-        $sitStr .= " at $pos $yl" if $pos && defined $yl;
+        $sitStr .= " at $pos" if $pos;
         push @parts, $sitStr;
       }
       if (ref($sit->{lastPlay}) eq 'HASH' && $sit->{lastPlay}{text}) {
@@ -447,6 +459,16 @@ my $prefix = getStandingsPrefix($abbrev, $teamId, $liveGame ? $liveGame->{id}
                                      : $nextGame ? $nextGame->{id} : '');
 
 if (defined $liveGame) {
+  # the schedule endpoint omits down/distance and last play; pull them
+  # from the scoreboard for the game's own date
+  if ($liveGame->{date} =~ /^(\d{4})-(\d{2})-(\d{2})/) {
+    my $sb = fetchJSON("$API/scoreboard?dates=$1$2$3");
+    foreach my $ev (@{$sb->{events} // []}) {
+      next unless ($ev->{id} // '') eq $liveGame->{id};
+      $liveGame->{comp}{situation} = $ev->{competitions}[0]{situation};
+      last;
+    }
+  }
   renderTeamLine($prefix, $liveGame);
 } elsif (defined $lastGame || defined $nextGame) {
   my $sep = " \x{00B7} ";
@@ -461,7 +483,8 @@ if (defined $liveGame) {
       my $nDate = fmtDateShort($nextGame->{short});
       my $nTime = fmtStartTime($nextGame->{short});
       my $nextLine = "Next ($nDate): " . teamColor(tabbr($nAway)) . "  at  " . teamColor(tabbr($nHome))
-          . ($nTime ? "  —  $nTime ET" : '');
+          . ($nTime ? "  —  $nTime ET" : '')
+          . ($nextGame->{tv} ? grey(" on $nextGame->{tv}") : '');
       print "\x{1F3C8} " . ($prefix ? "$prefix$sep" : '') . "$line$sep$nextLine\n";
     } else {
       print "\x{1F3C8} " . ($prefix ? "$prefix$sep" : '') . "$line\n";
@@ -472,7 +495,8 @@ if (defined $liveGame) {
     my $nDate = fmtDateShort($nextGame->{short});
     my $nTime = fmtStartTime($nextGame->{short});
     my $nextLine = "Next ($nDate): " . teamColor(tabbr($nAway)) . "  at  " . teamColor(tabbr($nHome))
-        . ($nTime ? "  —  $nTime ET" : '');
+        . ($nTime ? "  —  $nTime ET" : '')
+        . ($nextGame->{tv} ? grey(" on $nextGame->{tv}") : '');
     print "\x{1F3C8} " . ($prefix ? "$prefix$sep" : '') . "$nextLine\n";
   }
 } else {

--- a/lib/nfl
+++ b/lib/nfl
@@ -246,16 +246,21 @@ sub getGame {
     if (($c->{homeAway} // '') eq 'home') { $home = $c }
     elsif (($c->{homeAway} // '') eq 'away') { $away = $c }
   }
-  # national TV network; broadcast shapes differ between the schedule
-  # (market:{type}, media.shortName) and scoreboard (market, names[]) endpoints
+  # TV network: prefer the national broadcaster, falling back to the first
+  # regional/home-market station when none is listed (some preseason games).
+  # Broadcast shapes differ between the schedule (market:{type},
+  # media.shortName) and scoreboard (market, names[]) endpoints
+  my @regional;
   foreach my $b (@{$comp->{broadcasts} // []}) {
+    my $name = $b->{media}{shortName}
+        // (ref($b->{names}) eq 'ARRAY' && @{$b->{names}} ? $b->{names}[0] : '');
+    next unless $name;
     my $mkt = $b->{market} // '';
     $mkt = ref($mkt) eq 'HASH' ? ($mkt->{type} // '') : $mkt;
-    next unless lc($mkt) eq 'national';
-    $tv = $b->{media}{shortName} // '';
-    $tv = $b->{names}[0] // '' if !$tv && ref($b->{names}) eq 'ARRAY';
-    last if $tv;
+    if (lc($mkt) eq 'national') { $tv = $name; last }
+    push @regional, $name;
   }
+  $tv //= shift(@regional) // '';
   return {
     date     => $ev->{date} // '',
     id       => $ev->{id} // '',


### PR DESCRIPTION
Adds the TV network to all `!nfl` output:

- Team view live line: `🏈 · Jets (0-1) · 3rd in AFC East · NYJ(7) @ PIT(0) · Q2 9:23 · on NFL Net · 1st & 10 at NYJ 31 · Last: ...`
- Team view next game: `Next (8/22): PHI at NE — 7:00p ET on NFL Net`
- No-arg scoreboard, upcoming games only: `GB @ DEN 9:00p on NFL Net`

Implementation notes:
- All three endpoints already in use (schedule, scoreboard, summary) carry broadcast data; `getGame` now parses it once, handling both payload shapes (schedule: `market:{type:"National"}` + `media.shortName`; scoreboard: `market:"national"` + `names[]`). No extra HTTP requests.
- Prefers the national broadcaster. ESPN lists CBS/FOX as national even for regional regular-season windows (verified against four sampled 2025 Sundays and the 2025 schedule endpoint), so regular-season games always show a network. Some preseason games list only home/away market stations (e.g. Jets 8/28: WCBS); those fall back to the first regional station.
- botcommands.md updated.

Also fixes live team lookups showing no down/distance or last play (schedule endpoint returns `situation: null`; now enriched from the scoreboard endpoint), and a duplicated yard line in the possession text ("at PIT 41 41").