### PR TITLE
nfl: fetch live scores from scoreboard endpoint

### DIFF
--- a/lib/nfl
+++ b/lib/nfl
@@ -282,6 +282,35 @@ sub score {
   return ref($s) eq 'HASH' ? ($s->{displayValue} // 0) : ($s // 0);
 }
 
+# the schedule endpoint leaves scores null until the game goes final; pull
+# real scores from the scoreboard endpoint for the game date
+sub refreshScores {
+  my ($g) = @_;
+  return unless $g->{id} && $g->{date} =~ /^(\d{4})-(\d{2})-(\d{2})/;
+  my $data = fetchJSON("$API/scoreboard?dates=$1$2$3");
+  return unless $data && $data->{events};
+  foreach my $ev (@{$data->{events}}) {
+    next unless ($ev->{id} // '') eq $g->{id};
+    foreach my $c (@{$ev->{competitions}[0]{competitors} // []}) {
+      my $side = ($c->{homeAway} // '') eq 'home' ? $g->{home} : $g->{away};
+      next unless $side;
+      $side->{score} = $c->{score};
+    }
+    last;
+  }
+}
+
+# true if either competitor's score is absent (null or empty)
+sub scoresMissing {
+  my ($g) = @_;
+  foreach my $c ($g->{away} // {}, $g->{home} // {}) {
+    my $s = $c->{score};
+    $s = ref($s) eq 'HASH' ? ($s->{displayValue} // '') : $s;
+    return 1 unless defined $s && $s ne '';
+  }
+  return 0;
+}
+
 sub tabbr {
   my $c = shift // {};
   return $c->{team}{abbreviation} // '???';
@@ -451,8 +480,10 @@ my ($liveGame, $lastGame, $nextGame);
 foreach my $ev (@{$sched->{events}}) {
   my $g = getGame($ev);
   if ($g->{state} eq 'in') {
+    refreshScores($g) if scoresMissing($g);
     $liveGame = $g;
   } elsif ($g->{state} eq 'post' && $g->{date} le $today) {
+    refreshScores($g) if scoresMissing($g);
     $lastGame = $g;
   } elsif ($g->{state} ne 'post' && $g->{date} ge $today && !defined $nextGame) {
     $nextGame = $g;


### PR DESCRIPTION
## Problem

`!nfl <team>` reads scores from the schedule endpoint (`teams/<id>/schedule`), which returns `"score": null` while a game is in progress. Live games rendered as `PHI 0 @ NE 0 · Q4 15:00` even mid-drive.

Scores only appear there once the game goes final, so the existing "Last (date): ..." path was unaffected.

## Fix

During the schedule scan, any live or final game whose competitor scores are missing gets them refreshed from the scoreboard endpoint for that game's date (`scoreboard?dates=YYYYMMDD`), matched by event id:

- new `refreshScores()` / `scoresMissing()` helpers
- called only when scores are actually absent, so final/pregame games cost no extra request

## Verification

Live game output before/after matches ESPN's scoreboard payload:

```
🏈 · Eagles (0-1) · 4th in NFC East · PHI 14 @ NE 17 · Q4 13:33 · on NFL Net
```

Also confirmed unchanged behavior for finished games (`!nfl ravens`) and pregame teams (`!nfl cowboys`).